### PR TITLE
build: Allow commit messages to use caps

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,6 @@
-module.exports = { extends: ['@commitlint/config-conventional'] }
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'subject-case': [0]
+  }
+}


### PR DESCRIPTION
I don't know why we should care if the part after the machine-readable part has caps in it; weird default