### PR TITLE
feat: add UI for selecting a featured ERC20

### DIFF
--- a/src/css/global.css
+++ b/src/css/global.css
@@ -61,7 +61,16 @@ a:active,
   color: var(--secondary);
 }
 
-button, input {
+form {
+  margin: 3em 1em;
+}
+
+label {
+  display: block;
+  margin: -1em 0 0.1em;
+}
+
+button, input, select {
   font: inherit;
   outline: none;
 }
@@ -130,7 +139,7 @@ fieldset {
   padding: 0;
 }
 
-input {
+input, select {
   background-color: var(--shadow);
   border: none;
   border-radius: 5px 0 0 5px;

--- a/src/html/erc20-to-near.html
+++ b/src/html/erc20-to-near.html
@@ -1,104 +1,106 @@
-<div class="erc20-to-near" data-behavior="erc20-to-near">
-  <section class="balance">
-    <header>
-      <img alt="ethereum" src="img/eth-diamond-purple.png">
-      Ethereum
-    </header>
-    <div>
-      <span id="erc20name" class="dropdown" aria-live="polite">
-        <button aria-controls="erc20name" data-behavior="ethErc20Name">🤔</button>
-        <small class="left" style="width:27em; text-align:left">
-          Contract <code data-behavior="ethErc20Address">🤔</code>
-        </small>
-      </span>
-      balance
-    </div>
-    <strong class="jumbo" data-behavior="erc20Balance">🤔</strong>
-    <footer>
-      <img alt="account" src="img/account.svg">
-      <code data-behavior="ethUser" class="clip">🤔</code>
-    </footer>
-  </section>
-  <div data-behavior="notBridged" style="grid-column: span 2; margin: 1em 0 0 1em; display: none">
-    <p>
-      Not yet bridged!
-    </p>
-    <p>
-      The
-      <a href="https://github.com/near/rainbow-token-connector" target="_blank">Fungible Token Connector</a>
-      allows sending any
-      <a href="https://eips.ethereum.org/EIPS/eip-20" target="_blank">ERC20</a>
-      token to NEAR, but requires a one-time deploy of a "BridgeToken"
-      <a href="https://docs.near.org/docs/roles/developer/contracts/intro#get-started" target="_blank">smart contract</a>.
-      No one has deployed such a contract for this token yet.
-    </p>
-    <p>
-      But you can!
-    </p>
-    <p>
-      It will require about 30 Ⓝ to cover
-      <a href="https://docs.near.org/docs/concepts/storage" target="_blank">storage fees</a>.
-    </p>
-    <p>
-      <button>Bridge it!</button>
-    </p>
-  </div>
-  <div data-behavior="balanceZero" style="grid-column: span 2; margin: 1em 0 0 1em">
-    <p>
-      Uh oh! You have no <span data-behavior="ethErc20Name">🤔</span>
-      tokens. If you want to send some to yourself on NEAR, you'll need to
-      get some on Ethereum first 😄
-    </p>
-    <p data-behavior="abound-token" style="display: none">
-      You can <a href="https://chadoh.com/abundance-token" target="_blank">mint yourself more <span data-behavior="ethErc20Name">🤔</span></a>!
-    </p>
-    <p data-behavior="not-abound-token">
-      Maybe you need to use a different account?
-    </p>
-  </div>
-  <form data-behavior="balancePositive" style="display: none; margin: 3em 1em">
-    <fieldset id="fieldset">
-      <label
-        for="amount"
-        style="display: block; margin: -1em 0 0.1em"
-      >
-        Send
-      </label>
-      <div style="display: flex">
-        <input
-          autocomplete="off"
-          id="amount"
-          type="number"
-        />
-        <button id="submit" aria-controls="transfers" disabled style="border-radius: 0 5px 5px 0">
-          <span class="visually-hidden">Confirm</span>
-        </button>
+<div class="erc20-to-near" data-behavior="erc20-to-near" style="display: none">
+  <div class="grid">
+    <section class="balance">
+      <header>
+        <img alt="ethereum" src="img/eth-diamond-purple.png">
+        Ethereum
+      </header>
+      <div>
+        <span id="erc20name" class="dropdown" aria-live="polite">
+          <button aria-controls="erc20name" data-behavior="ethErc20Name">🤔</button>
+          <small class="left" style="width:27em; text-align:left">
+            Contract <code data-behavior="ethErc20Address">🤔</code>
+          </small>
+        </span>
+        balance
       </div>
-    </fieldset>
-  </form>
-  <section class="balance" data-behavior="balancePositive" style="display: none">
-    <header>
-      <picture>
-        <source srcset="img/near-icon-white.svg" media="(prefers-color-scheme: dark)">
-        <img alt="near" src="img/near-icon-black.svg">
-      </picture>
-      NEAR
-    </header>
-    <div>
-      <span id="nep21name" class="dropdown" aria-live="polite">
-        <button aria-controls="nep21name" data-behavior="nearNep21Name">🤔</button>
-        <small class="right" style="width:14em">
-          Contract <code data-behavior="nearFunTokenAccount">🤔</code>
-        </small>
-      </span>
-      balance
+      <strong class="jumbo" data-behavior="erc20Balance">🤔</strong>
+      <footer>
+        <img alt="account" src="img/account.svg">
+        <code data-behavior="ethUser" class="clip">🤔</code>
+      </footer>
+    </section>
+    <div data-behavior="notBridged" style="grid-column: span 2; margin: 1em 0 0 1em; display: none">
+      <p>
+        Not yet bridged!
+      </p>
+      <p>
+        The
+        <a href="https://github.com/near/rainbow-token-connector" target="_blank">Fungible Token Connector</a>
+        allows sending any
+        <a href="https://eips.ethereum.org/EIPS/eip-20" target="_blank">ERC20</a>
+        token to NEAR, but requires a one-time deploy of a "BridgeToken"
+        <a href="https://docs.near.org/docs/roles/developer/contracts/intro#get-started" target="_blank">smart contract</a>.
+        No one has deployed such a contract for this token yet.
+      </p>
+      <p>
+        But you can!
+      </p>
+      <p>
+        It will require about 30 Ⓝ to cover
+        <a href="https://docs.near.org/docs/concepts/storage" target="_blank">storage fees</a>.
+      </p>
+      <p>
+        <button>Bridge it!</button>
+      </p>
     </div>
-    <strong class="jumbo" data-behavior="nep21Balance">🤔</strong>
-    <footer>
-      <img alt="account" src="img/account.svg">
-      <code data-behavior="nearUser" class="clip">🤔</code>
-    </footer>
-  </section>
+    <div data-behavior="balanceZero" style="grid-column: span 2; margin: 1em 0 0 1em">
+      <p>
+        Uh oh! You have no <span data-behavior="ethErc20Name">🤔</span>
+        tokens. If you want to send some to yourself on NEAR, you'll need to
+        get some on Ethereum first 😄
+      </p>
+      <p data-behavior="abound-token" style="display: none">
+        You can <a href="https://chadoh.com/abundance-token" target="_blank">mint yourself more <span data-behavior="ethErc20Name">🤔</span></a>!
+      </p>
+      <p data-behavior="not-abound-token">
+        Maybe you need to use a different account?
+      </p>
+    </div>
+    <form data-behavior="balancePositive" style="display: none">
+      <fieldset id="fieldset">
+        <label for="amount">Send</label>
+        <div style="display: flex">
+          <input
+            autocomplete="off"
+            id="amount"
+            type="number"
+          />
+          <button id="submit" aria-controls="transfers" disabled style="border-radius: 0 5px 5px 0">
+            <span class="visually-hidden">Confirm</span>
+          </button>
+        </div>
+      </fieldset>
+    </form>
+    <section class="balance" data-behavior="balancePositive" style="display: none">
+      <header>
+        <picture>
+          <source srcset="img/near-icon-white.svg" media="(prefers-color-scheme: dark)">
+          <img alt="near" src="img/near-icon-black.svg">
+        </picture>
+        NEAR
+      </header>
+      <div>
+        <span id="nep21name" class="dropdown" aria-live="polite">
+          <button aria-controls="nep21name" data-behavior="nearNep21Name">🤔</button>
+          <small class="right" style="width:14em">
+            Contract <code data-behavior="nearFunTokenAccount">🤔</code>
+          </small>
+        </span>
+        balance
+      </div>
+      <strong class="jumbo" data-behavior="nep21Balance">🤔</strong>
+      <footer>
+        <img alt="account" src="img/account.svg">
+        <code data-behavior="nearUser" class="clip">🤔</code>
+      </footer>
+    </section>
+  </div>
+  <p style="text-align: center; margin-top: 3rem">
+    <button style="background: var(--error)" data-behavior="cancelSendingErc20">
+      Cancel
+    </button>
+  </p>
 </div>
 <script>
   window.addEventListener('load', function addErc20ToNearHandlers () {
@@ -125,7 +127,7 @@
         await window.initiateTransfer({
           amount: amount.value,
           callback: window.render,
-          erc20: window.getParam('erc20')
+          erc20: window.urlParams.get('erc20')
         })
       } catch (e) {
         alert(
@@ -142,14 +144,16 @@
       // if the call succeeded, reset the form
       amount.value = ''
       submit.disabled = true
+      window.urlParams.clear('erc20')
       await render()
       const transfersButton = document.querySelector('#transfers button')
       transfersButton.click()
       transfersButton.focus()
     }
+
     document.querySelector('[data-behavior=notBridged] button').onclick = function bridgeIt () {
       window.nearFungibleTokenFactory.deploy_bridge_token(
-        { address: window.getParam('erc20').replace('0x', '') },
+        { address: window.urlParams.get('erc20').replace('0x', '') },
 
         // Default gas limit used by near-api-js is 3e13, but this tx fails with
         // that number. Doubling it works. Maybe slightly less would also work,
@@ -165,9 +169,37 @@
         new window.BN(window.parseNearAmount('30.02'))
       )
     }
+
+    document.querySelector('[data-behavior=cancelSendingErc20]').onclick = function cancelSendingErc20 () {
+      window.urlParams.clear('erc20')
+      window.render()
+    }
   })
 
   async function renderErc20ToNear () {
+    const ethErc20Address = window.urlParams.get('erc20')
+
+    if (ethErc20Address) {
+      window.show('erc20-to-near')
+    } else {
+      // user has not selected an ERC20 to send to NEAR; return early
+      window.hide('erc20-to-near')
+      return
+    }
+
+    // quickly clear displayed balances, since refetch can take a second
+    const prevErc20Address = document.querySelector('[data-behavior=ethErc20Address]').innerText
+    if (ethErc20Address !== prevErc20Address) {
+      window.fill('erc20Balance').with('•••')
+      window.fill('nep21Balance').with('•••')
+    }
+
+    const ethErc20Name = await window.getErc20Name(ethErc20Address)
+
+    window.fill('ethErc20Name').with(ethErc20Name)
+    window.fill('ethErc20Address').with(ethErc20Address)
+    window.fill('nearNep21Name').with('n' + ethErc20Name)
+
     window.fill('ethUser').with(window.ethUserAddress)
     window.fill('nearUser').with(window.nearUserAddress)
 
@@ -175,10 +207,7 @@
     window.fill('ethNetworkName').with(await window.web3.eth.net.getNetworkType())
 
     const erc20Balance = await getErc20Balance()
-    const nep21Balance = await getNep21Balance()
-
     window.fill('erc20Balance').with(formatLargeNum(erc20Balance))
-
 
     if (erc20Balance === 0) {
       window.hide('balancePositive')
@@ -192,6 +221,7 @@
         window.show('not-abound-token')
       }
     } else {
+      const nep21Balance = await getNep21Balance()
       if (nep21Balance === null) {
         window.hide('balancePositive')
         window.hide('balanceZero')
@@ -212,7 +242,7 @@
   async function getErc20Balance () {
     const erc20Contract = new window.web3.eth.Contract(
       JSON.parse(process.env.ethErc20AbiText),
-      window.getParam('erc20'),
+      window.urlParams.get('erc20'),
       { from: window.ethUserAddress }
     )
 
@@ -223,7 +253,7 @@
 
   async function getNep21Balance () {
     const nep21Address =
-      window.getParam('erc20').replace('0x', '').toLowerCase() +
+      window.urlParams.get('erc20').replace('0x', '').toLowerCase() +
       '.' +
       process.env.nearTokenFactoryAccount
 
@@ -244,12 +274,14 @@
 </script>
 <style>
   .erc20-to-near {
-    align-items: stretch;
-    grid-template-columns: repeat(3, minmax(10em, 1fr));
     margin: 4rem auto;
     max-width: 20em;
   }
-  .erc20-to-near > * {
+  .erc20-to-near .grid {
+    align-items: stretch;
+    grid-template-columns: repeat(3, minmax(10em, 1fr));
+  }
+  .erc20-to-near .grid > * {
     display: flex;
     flex-direction: column;
     justify-content: space-around;
@@ -287,8 +319,10 @@
   }
   @media(min-width: 650px) {
     .erc20-to-near {
-      display: grid;
       max-width: 40em;
+    }
+    .erc20-to-near .grid {
+      display: grid;
     }
     .erc20-to-near form button:after {
       content: '→';

--- a/src/html/select-erc20.html
+++ b/src/html/select-erc20.html
@@ -1,0 +1,47 @@
+<form data-behavior="select-erc20" class="select-erc20" method="get">
+  <label for="erc20">
+    Select an ERC20 token to send to NEAR
+  </label>
+  <div style="display: flex">
+    <select id="erc20" name="erc20" data-behavior="erc20Selector">
+    </select>
+    <button id="submit" style="border-radius: 0 5px 5px 0">
+      Go
+    </button>
+  </div>
+</form>
+<script>
+  window.addEventListener('load', function handleSelectErc20Events () {
+    document.querySelector('[data-behavior=select-erc20]').onsubmit = e => {
+      e.preventDefault()
+      window.urlParams.set({ erc20: e.target.elements.erc20.value })
+      window.render()
+    }
+  })
+
+  async function renderSelectErc20 () {
+    if (window.urlParams.get('erc20')) window.hide('select-erc20')
+    else window.show('select-erc20')
+
+    const featuredErc20s = await Promise.all(
+      process.env.featuredErc20s.split(',').map(async address => {
+        const name = await window.getErc20Name(address)
+        return { address, name }
+      })
+    )
+
+    window.fill('erc20Selector').with(
+      featuredErc20s.map(({ address, name }) =>
+        `<option value="${address}">${name}</option>`
+      )
+    )
+  }
+
+  window.renderers.push(renderSelectErc20)
+</script>
+<style>
+  .select-erc20 {
+    margin: 4rem auto;
+    max-width: 20em;
+  }
+</style>

--- a/src/index.html
+++ b/src/index.html
@@ -22,6 +22,7 @@
   <include src="nav.html"></include>
   <include src="signed-out.html"></include>
   <main data-behavior="signed-in" style="display: none">
+    <include src="select-erc20.html"></include>
     <include src="erc20-to-near.html"></include>
   </main>
 

--- a/src/js/domHelpers.js
+++ b/src/js/domHelpers.js
@@ -1,25 +1,22 @@
-import BN from 'bn.js'
-import { utils } from 'near-api-js'
-import {
-  clear as clearTransfer,
-  initiate as initiateTransfer,
-  retry as retryTransfer
-} from './transfers'
-import render from './render'
-import { get as getParam } from './urlParams'
+const fillCache = {}
 
 // Update DOM elements that have a "data-behavior" attribute
 // Given `<span data-behavior="thing"></span>`
 // You can `fill('thing').with('whatever')` to set the innerHTML
 export const fill = selector => ({
-  with: content =>
-    Array.from(document.querySelectorAll(`[data-behavior=${selector}]`))
-      .forEach(n => {
-        n.innerHTML = Array.isArray(content) ? content.join('') : content
-        if (n.className.match('clip')) {
-          n.title = content
-        }
-      })
+  with: content => {
+    const contentString = Array.isArray(content) ? content.join('') : content
+    if (fillCache[selector] !== contentString) {
+      fillCache[selector] = contentString
+      Array.from(document.querySelectorAll(`[data-behavior=${selector}]`))
+        .forEach(n => {
+          n.innerHTML = contentString
+          if (n.className.match('clip')) {
+            n.title = contentString
+          }
+        })
+    }
+  }
 })
 
 // Hide DOM elements that have the given "data-behavior" attribute

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -3,8 +3,9 @@ import { Contract as NearContract, utils } from 'near-api-js'
 import './authEthereum'
 import './authNear'
 import { fill, hide, initDOMhandlers, show } from './domHelpers'
-import { get as getParam, set as setParam } from './urlParams'
+import { getErc20Name } from './ethHelpers'
 import render from './render'
+import * as urlParams from './urlParams'
 import {
   get as getTransfers,
   initiate as initiateTransfer,
@@ -14,7 +15,7 @@ import {
 // Can't import modules in <script> tags in files included via PostHTML 😞
 window.BN = BN
 window.fill = fill
-window.getParam = getParam
+window.getErc20Name = getErc20Name
 window.getTransfers = getTransfers
 window.hide = hide
 window.humanStatusFor = humanStatusFor
@@ -23,10 +24,7 @@ window.NearContract = NearContract
 window.parseNearAmount = utils.format.parseNearAmount
 window.render = render
 window.show = show
-
-if (!getParam('erc20')) {
-  setParam({ erc20: process.env.featuredErc20s.split(',')[0] })
-}
+window.urlParams = urlParams
 
 initDOMhandlers()
 render()

--- a/src/js/render.js
+++ b/src/js/render.js
@@ -1,6 +1,4 @@
 import { fill, hide, show } from './domHelpers'
-import { get as getParam } from './urlParams'
-import { getErc20Name } from './ethHelpers'
 
 // update the html based on user & data state
 export default async function render () {
@@ -14,13 +12,6 @@ export default async function render () {
 
   // if not signed in with both eth & near, stop here
   if (!window.ethUserAddress || !window.nearUserAddress) return
-
-  const ethErc20Address = getParam('erc20')
-  const ethErc20Name = await getErc20Name(ethErc20Address)
-
-  fill('ethErc20Name').with(ethErc20Name)
-  fill('ethErc20Address').with(ethErc20Address)
-  fill('nearNep21Name').with('n' + ethErc20Name)
 
   await Promise.all(window.renderers.map(r => r()))
 

--- a/src/js/urlParams.js
+++ b/src/js/urlParams.js
@@ -21,10 +21,14 @@ export function set (newParams) {
 
 export function clear (...paramNames) {
   if (paramNames.length === 0) {
-    window.history.replaceState({}, '', `${location.pathname}`)
+    window.history.replaceState({}, '', location.pathname)
   } else {
     const params = new URLSearchParams(window.location.search)
     paramNames.forEach(p => params.delete(p))
-    window.history.replaceState({}, '', `${location.pathname}?${params}`)
+    if (params.toString()) {
+      window.history.replaceState({}, '', `${location.pathname}?${params}`)
+    } else {
+      window.history.replaceState({}, '', location.pathname)
+    }
   }
 }


### PR DESCRIPTION
Fixes #28

The signed-in UI now shows a select box with a list of featured ERC20
tokens. Once you select one, the URL updates and the form is shown to
send one.

This also includes some usability-focused tweaks to helper functions:

* `urlParams.clear` clears the `?` from the URL when clearing last param
* `fill` keeps a cache and doesn't re-paint needlessly. This means that
  when you select an ERC20 to send but then cancel, the select dropdown
  still has the same item selected.

Note that filling in your own erc20 address in the URL is supported,
but the UI itself does not expose this functionality.