### PR TITLE
fix: undefined 'get_balance'

### DIFF
--- a/src/html/erc20-to-near.html
+++ b/src/html/erc20-to-near.html
@@ -124,7 +124,7 @@
       fieldset.disabled = true
 
       try {
-        await window.initiateTransfer({
+        await window.transfers.initiate({
           amount: amount.value,
           callback: window.render,
           erc20: window.urlParams.get('erc20')
@@ -260,9 +260,7 @@
     const nep21 = await new window.NearContract(
       window.nearConnection.account(),
       nep21Address,
-      {
-        viewMethods: ['get_balance']
-      }
+      { viewMethods: ['get_balance'] }
     )
 
     return nep21.get_balance({ owner_id: window.nearUserAddress })

--- a/src/html/nav.html
+++ b/src/html/nav.html
@@ -74,7 +74,7 @@
       if (!clearTransferButton) return
 
       const transferId = clearTransferButton.closest('[data-behavior=transfer]').id
-      clearTransfer(transferId)
+      window.transfers.clear(transferId)
       render()
     })
 
@@ -87,7 +87,7 @@
       if (!retryTransferButton) return
 
       const transferId = retryTransferButton.closest('[data-behavior=transfer]').id
-      retryTransfer(transferId, render)
+      window.transfers.retry(transferId, render)
     })
   })
 
@@ -108,7 +108,7 @@
           <span>${'n' + transfer.erc20Name}</span>
         </header>
         <div>
-          <p>${window.humanStatusFor(transfer)}</p>
+          <p>${window.transfers.humanStatusFor(transfer)}</p>
         </div>
         ${inProgress ? '' : `
           <footer>
@@ -130,7 +130,7 @@
   }
 
   async function updateTransfers () {
-    const { inProgress, complete } = window.getTransfers()
+    const { inProgress, complete } = window.transfers.get()
 
     if (!inProgress.length && !complete.length) {
       show('transfers-none')

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -6,24 +6,18 @@ import { fill, hide, initDOMhandlers, show } from './domHelpers'
 import { getErc20Name } from './ethHelpers'
 import render from './render'
 import * as urlParams from './urlParams'
-import {
-  get as getTransfers,
-  initiate as initiateTransfer,
-  humanStatusFor
-} from './transfers'
+import * as transfers from './transfers'
 
 // Can't import modules in <script> tags in files included via PostHTML 😞
 window.BN = BN
 window.fill = fill
 window.getErc20Name = getErc20Name
-window.getTransfers = getTransfers
 window.hide = hide
-window.humanStatusFor = humanStatusFor
-window.initiateTransfer = initiateTransfer
 window.NearContract = NearContract
 window.parseNearAmount = utils.format.parseNearAmount
 window.render = render
 window.show = show
+window.transfers = transfers
 window.urlParams = urlParams
 
 initDOMhandlers()


### PR DESCRIPTION
This bug was introduced in 43ac0b454b2523b8380c05509b5988b4adef9548

Since ea9de4c457d49873f63a6858340447fb063d6623, there's been no logical global `window.nep21`, but `transfers` was still relying on one.