### PR TITLE
explore: deal with NEAR Wallet redirect using queue

### DIFF
--- a/src/js/authNear.js
+++ b/src/js/authNear.js
@@ -1,8 +1,6 @@
 import { Contract, keyStores, WalletConnection, Near } from 'near-api-js'
 
 import { checkStatuses as checkTransferStatuses } from './transfers'
-import * as storage from './transfers/storage'
-import { processWithdrawTx, INITIALIZED } from './transfers/bridged-nep21-to-erc20'
 import EthOnNearClient from './borsh/ethOnNearClient'
 import render from './render'
 
@@ -57,16 +55,7 @@ async function login () {
 
   render()
 
-  if (window.ethInitialized) {
-    window.nearConnection.inFlightTransactions.drain(({ meta, tx }) => {
-      const transfer = storage.get(meta.id)
-
-      if (transfer.nep21FromErc20 && transfer.status === INITIALIZED) {
-        processWithdrawTx(transfer, tx)
-      }
-    })
-    checkTransferStatuses(render)
-  }
+  if (window.ethInitialized) checkTransferStatuses(render)
 }
 
 // The NEAR signin flow redirects from the current URL to NEAR Wallet,


### PR DESCRIPTION
_I recommend viewing the diff [with indentation changes hidden](https://github.com/near/rainbow-bridge-frontend/pull/48/files?w=1)_

This adds some non-functional code to explore a possible way to deal with NEAR Wallet redirects. ~This approach ONLY works if the contract call does, in fact, cause a redirect.~ As of the second commit, this approach works whether or not the call results in a redirect.

The basic idea is to add ~the~ every transaction to an ~inFlightTransactions~ queue rather than sending it directly, which allows adding some metadata so that the app can identify what transaction this is for upon ~initial~ subsequent page load.

~In this particular app, that metadata is used to find the correct transfer and determine which step of the transfer it's at, so it can call the correct next function.~

~Without significant rework, this approach feels doomed to lead to hard-to-understand code, with related functionality spread throughout the codebase, and exported constants & functions that didn't previously need to be exported.~

_Again, I recommend viewing the diff [with indentation changes hidden](https://github.com/near/rainbow-bridge-frontend/pull/48/files?w=1)_