### PR TITLE
feat: use PouchDB to sync data across devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Exploring the code
 
    * Note the imports of files named `authEthereum` & `authNear`. These imports have side effects, adding behavior to the buttons with matching `data-behavior` attributes. The Ethereum- and NEAR-specific stuff is mostly contained within these files, so you can compare the authentication & contract-initialization code side-by-side.
    * `initDOMHandlers` is a function that needs to be called once after page load, to add behavior like dropdown toggling & form submission. Check out [domHelpers.js](./src/js/domHelpers.js) to see the simple setup here.
-   * `render` is a function which doesn't truly _render_, if you're used to thinking about rendering from a framework like React. Instead, this function procedurally updates the DOM based on current app state. Open [render.js](./src/js/render.js) to see everything it does. This function gets called again in both [authEthereum](./src/js/authEthereum.js) and [authNear](./src/js/authNear.js) after login. It also gets passed as a callback to `checkTransferStatuses` – more on this next!
+   * `render` is a function which doesn't truly _render_, if you're used to thinking about rendering from a framework like React. Instead, this function procedurally updates the DOM based on current app state. Open [render.js](./src/js/render.js) to see everything it does. This function gets called again in both [authEthereum](./src/js/authEthereum.js) and [authNear](./src/js/authNear.js) after login.
 
 4. [transfers.js](./src/js/transfers.js): the main Rainbow Bridge logic!
 

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eth-revert-reason": "^1.0.3",
     "eth-util-lite": "near/eth-util-lite#master",
     "near-api-js": "near/near-api-js#allow-borsh-deserialization",
+    "pouchdb-browser": "^7.2.2",
     "promisfy": "^1.2.0",
     "web3": "^1.2.11",
     "web3modal": "^1.9.0"

--- a/src/html/nav.html
+++ b/src/html/nav.html
@@ -130,7 +130,7 @@
   }
 
   async function updateTransfers () {
-    const { inProgress, complete } = window.transfers.get()
+    const { inProgress, complete } = await window.transfers.get()
 
     if (!inProgress.length && !complete.length) {
       show('transfers-none')

--- a/src/html/send-erc20.html
+++ b/src/html/send-erc20.html
@@ -195,7 +195,6 @@
       },
       action: amount => window.transfers.initiate({
         amount,
-        callback: window.render,
         naturalErc20: window.urlParams.get('erc20')
       }),
       after: ({ toEth }) => {
@@ -211,7 +210,6 @@
       },
       action: amount => window.transfers.initiate({
         amount,
-        callback: window.render,
         nep21FromErc20: getNep21Address(window.urlParams.get('erc20'))
       }),
       after: ({ toNear }) => {

--- a/src/js/authEthereum.js
+++ b/src/js/authEthereum.js
@@ -55,7 +55,7 @@ async function login (provider) {
   button.replaceWith(span)
   render()
 
-  if (window.nearInitialized) checkTransferStatuses(render)
+  if (window.nearInitialized) checkTransferStatuses()
 }
 
 async function loadWeb3Modal () {

--- a/src/js/authNear.js
+++ b/src/js/authNear.js
@@ -55,7 +55,7 @@ async function login () {
 
   render()
 
-  if (window.ethInitialized) checkTransferStatuses(render)
+  if (window.ethInitialized) checkTransferStatuses()
 }
 
 // The NEAR signin flow redirects from the current URL to NEAR Wallet,

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -22,3 +22,5 @@ window.urlParams = urlParams
 
 initDOMhandlers()
 render()
+
+transfers.onChange(render)

--- a/src/js/transfers/bridged-nep21-to-erc20/index.js
+++ b/src/js/transfers/bridged-nep21-to-erc20/index.js
@@ -94,14 +94,14 @@ export async function checkStatus (transfer) {
     // causes redirect to NEAR Wallet and subsequent update of transfer
     const withdrawal = await withdraw(transfer)
     if (withdrawal.failed) {
-      transfer = storage.update(transfer, {
+      transfer = await storage.update(transfer, {
         status: COMPLETE,
         outcome: FAILED,
         failedAt: WITHDRAWN,
         error: transfer.error
       })
     } else {
-      transfer = storage.update(transfer, {
+      transfer = await storage.update(transfer, {
         ...withdrawal,
         status: WITHDRAWN
       })
@@ -112,13 +112,13 @@ export async function checkStatus (transfer) {
     try {
       const outcomeBlock = await findOutcomeBlock(transfer)
       if (outcomeBlock) {
-        transfer = storage.update(transfer, {
+        transfer = await storage.update(transfer, {
           ...outcomeBlock,
           status: FOUND_OUTCOME
         })
       }
     } catch (error) {
-      transfer = storage.update(transfer, {
+      transfer = await storage.update(transfer, {
         status: COMPLETE,
         outcome: FAILED,
         failedAt: WITHDRAWN,
@@ -131,13 +131,13 @@ export async function checkStatus (transfer) {
     try {
       const ethBlockInfo = await findEthBlock(transfer)
       if (ethBlockInfo) {
-        transfer = storage.update(transfer, {
+        transfer = await storage.update(transfer, {
           ...ethBlockInfo,
           status: FOUND_ETH_BLOCK
         })
       }
     } catch (error) {
-      transfer = storage.update(transfer, {
+      transfer = await storage.update(transfer, {
         status: COMPLETE,
         outcome: FAILED,
         failedAt: FOUND_OUTCOME,
@@ -150,12 +150,12 @@ export async function checkStatus (transfer) {
     try {
       const securityWindowClosed = await checkSecurityWindowClosed(transfer)
       if (securityWindowClosed) {
-        transfer = storage.update(transfer, {
+        transfer = await storage.update(transfer, {
           status: SECURITY_WINDOW_CLOSED
         })
       }
     } catch (error) {
-      transfer = storage.update(transfer, {
+      transfer = await storage.update(transfer, {
         status: COMPLETE,
         outcome: FAILED,
         failedAt: FOUND_ETH_BLOCK,
@@ -167,12 +167,12 @@ export async function checkStatus (transfer) {
   if (transfer.status === SECURITY_WINDOW_CLOSED) {
     try {
       await unlock(transfer)
-      transfer = storage.update(transfer, {
+      transfer = await storage.update(transfer, {
         outcome: SUCCESS,
         status: COMPLETE
       })
     } catch (error) {
-      transfer = storage.update(transfer, {
+      transfer = await storage.update(transfer, {
         status: COMPLETE,
         outcome: FAILED,
         failedAt: SECURITY_WINDOW_CLOSED,
@@ -189,12 +189,12 @@ export async function retry (transfer) {
     case SECURITY_WINDOW_CLOSED:
       try {
         await unlock(transfer)
-        transfer = storage.update(transfer, {
+        transfer = await storage.update(transfer, {
           outcome: SUCCESS,
           status: COMPLETE
         })
       } catch (error) {
-        transfer = storage.update(transfer, {
+        transfer = await storage.update(transfer, {
           status: COMPLETE,
           outcome: FAILED,
           failedAt: SECURITY_WINDOW_CLOSED,

--- a/src/js/transfers/storage.js
+++ b/src/js/transfers/storage.js
@@ -40,3 +40,10 @@ export async function update (transfer, withData) {
 export async function clear (id) {
   return await db.remove(id)
 }
+
+export function onChange (fn) {
+  db.changes({
+    since: 'now',
+    live: true
+  }).on('change', fn)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2095,6 +2095,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argsarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/argsarray/-/argsarray-0.0.1.tgz#6e7207b4ecdb39b0af88303fa5ae22bda8df61cb"
+  integrity sha1-bnIHtOzbObCviDA/pa4ivajfYcs=
+
 argv-formatter@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/argv-formatter/-/argv-formatter-1.0.0.tgz#a0ca0cbc29a5b73e836eebe1cbf6c5e0e4eb82f9"
@@ -6536,7 +6541,7 @@ ignore@^5.1.1, ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.8.tgz#f150a8b50a34289b33e22f5889abd4d8016f0e57"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
-immediate@^3.2.3:
+immediate@3.3.0, immediate@^3.2.3:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/immediate/-/immediate-3.3.0.tgz#1aef225517836bcdf7f2a2de2600c79ff0269266"
   integrity sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==
@@ -10118,6 +10123,18 @@ posthtml@^0.13.3, posthtml@^0.13.4:
     posthtml-parser "^0.5.0"
     posthtml-render "^1.2.3"
 
+pouchdb-browser@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/pouchdb-browser/-/pouchdb-browser-7.2.2.tgz#cf933cb25661b31c6691f7038f8fc3f757c093d0"
+  integrity sha512-90pkngk9/F95knUwOhGQ0xuNzG51uIecF5kD5AfNdhqqrV9wbngz+I3QA7u/9eVyZRVyOrTrT3oaKcNqAB7Brg==
+  dependencies:
+    argsarray "0.0.1"
+    immediate "3.3.0"
+    inherits "2.0.4"
+    spark-md5 "3.0.1"
+    uuid "8.1.0"
+    vuvuzela "1.0.3"
+
 preact@10.4.1:
   version "10.4.1"
   resolved "https://registry.yarnpkg.com/preact/-/preact-10.4.1.tgz#9b3ba020547673a231c6cf16f0fbaef0e8863431"
@@ -11555,6 +11572,11 @@ source-map@^0.5.0, source-map@^0.5.6:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
+spark-md5@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.1.tgz#83a0e255734f2ab4e5c466e5a2cfc9ba2aa2124d"
+  integrity sha512-0tF3AGSD1ppQeuffsLDIOWlKUd3lS92tFxcsrh5Pe3ZphhnoK+oXIBTzOAThZCiuINZLvpiLH/1VS1/ANEJVig==
+
 spawn-error-forwarder@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/spawn-error-forwarder/-/spawn-error-forwarder-1.0.0.tgz#1afd94738e999b0346d7b9fc373be55e07577029"
@@ -12748,6 +12770,11 @@ uuid@3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
+uuid@8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.1.0.tgz#6f1536eb43249f473abc6bd58ff983da1ca30d8d"
+  integrity sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg==
+
 uuid@^3.2.1, uuid@^3.3.2, uuid@^3.3.3:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
@@ -12813,6 +12840,11 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+vuvuzela@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/vuvuzela/-/vuvuzela-1.0.3.tgz#3be145e58271c73ca55279dd851f12a682114b0b"
+  integrity sha1-O+FF5YJxxzylUnndhR8SpoIRSws=
 
 w3c-hr-time@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
When you start a transfer on one device, you should be able to sign into the
same accounts on a different device and see/continue those same transfers.

This explores using [PouchDB](https://pouchdb.com/) to sync this data.

## Useful lessons

Even if we don't end up adding PouchDB, we can learn from the architectural changes it required.

* `async` interface to `storage` library seems like a more universal interface, rather than assuming synchronous localStorage writes
* `onChange` interface on `transfers` cleans up lots of code, since the need for passing a `callback` to various `transfers` functions goes away, and specifically revealed a more explicit `loop: true` interface for `checkStatus`