### PR TITLE
feat: add dumbest possible syncing

### DIFF
--- a/src/js/transfers/storage.js
+++ b/src/js/transfers/storage.js
@@ -1,7 +1,14 @@
 import PouchDB from 'pouchdb-browser'
 
-const db = new PouchDB('rainbow-bridge-transfers')
-const remoteCouch = false // eslint-disable-line no-unused-vars
+const LOCAL_DB = 'rainbow-bridge-transfers'
+const REMOTE_DB = `https://apikey-a0d8c8c11d224196b7ea464c42e39a60:eb44e84a1120e186fb0af806d436cf2bb891ae58@32114ed0-9b02-4a9b-9f93-de07a5616483-bluemix.cloudant.com/rainbow-bridge-${process.env.nearNetworkId}`
+
+const db = new PouchDB(LOCAL_DB)
+
+PouchDB.replicate(REMOTE_DB, LOCAL_DB, {
+  live: true,
+  retry: true
+})
 
 // Get raw transfers, stored in localStorage as an object indexed by keys
 export async function getAll () {


### PR DESCRIPTION
This is the dumbest possible syncing approach for #55, syncing all data between all users! Obviously a terrible syncing approach, but the easiest proof-of-concept to make quickly.

Figuring out a good way to add authentication to PouchDB/CouchDB is actually fairly BYO and more complicated than I hoped. One COULD use keys prefixed with a given user's eth & NEAR addresses, then filter for these records for a given user. But this makes it easy for an attacker to add noise, spam, and potentially worse attacks that would show up for other users.

The [database per user][1] approach seems close to what we would want, but it wasn't obvious how to pull this off with Cloudant, the backend being used here. And besides, what we really want is blockchain-based verification. This would probably require a small service to sit on the server between the PouchDB frontend connections and CloudDB.

  [1]: https://github.com/pouchdb-community/pouchdb-authentication/blob/master/docs/recipes.md#couch_peruser-configuration