### PR TITLE
refactor(storage)!: make async, export onChanges

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Exploring the code
 
    * Note the imports of files named `authEthereum` & `authNear`. These imports have side effects, adding behavior to the buttons with matching `data-behavior` attributes. The Ethereum- and NEAR-specific stuff is mostly contained within these files, so you can compare the authentication & contract-initialization code side-by-side.
    * `initDOMHandlers` is a function that needs to be called once after page load, to add behavior like dropdown toggling & form submission. Check out [domHelpers.js](./src/js/domHelpers.js) to see the simple setup here.
-   * `render` is a function which doesn't truly _render_, if you're used to thinking about rendering from a framework like React. Instead, this function procedurally updates the DOM based on current app state. Open [render.js](./src/js/render.js) to see everything it does. This function gets called again in both [authEthereum](./src/js/authEthereum.js) and [authNear](./src/js/authNear.js) after login. It also gets passed as a callback to `checkTransferStatuses` – more on this next!
+   * `render` is a function which doesn't truly _render_, if you're used to thinking about rendering from a framework like React. Instead, this function procedurally updates the DOM based on current app state. Open [render.js](./src/js/render.js) to see everything it does. This function gets called again in both [authEthereum](./src/js/authEthereum.js) and [authNear](./src/js/authNear.js) after login.
 
 4. [transfers.js](./src/js/transfers.js): the main Rainbow Bridge logic!
 

--- a/src/html/nav.html
+++ b/src/html/nav.html
@@ -130,7 +130,7 @@
   }
 
   async function updateTransfers () {
-    const { inProgress, complete } = window.transfers.get()
+    const { inProgress, complete } = await window.transfers.get()
 
     if (!inProgress.length && !complete.length) {
       show('transfers-none')

--- a/src/html/send-erc20.html
+++ b/src/html/send-erc20.html
@@ -195,7 +195,6 @@
       },
       action: amount => window.transfers.initiate({
         amount,
-        callback: window.render,
         naturalErc20: window.urlParams.get('erc20')
       }),
       after: ({ toEth }) => {
@@ -211,7 +210,6 @@
       },
       action: amount => window.transfers.initiate({
         amount,
-        callback: window.render,
         nep21FromErc20: getNep21Address(window.urlParams.get('erc20'))
       }),
       after: ({ toNear }) => {

--- a/src/js/authEthereum.js
+++ b/src/js/authEthereum.js
@@ -55,7 +55,7 @@ async function login (provider) {
   button.replaceWith(span)
   render()
 
-  if (window.nearInitialized) checkTransferStatuses(render)
+  if (window.nearInitialized) checkTransferStatuses()
 }
 
 async function loadWeb3Modal () {

--- a/src/js/authNear.js
+++ b/src/js/authNear.js
@@ -55,7 +55,7 @@ async function login () {
 
   render()
 
-  if (window.ethInitialized) checkTransferStatuses(render)
+  if (window.ethInitialized) checkTransferStatuses()
 }
 
 // The NEAR signin flow redirects from the current URL to NEAR Wallet,

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -22,3 +22,5 @@ window.urlParams = urlParams
 
 initDOMhandlers()
 render()
+
+transfers.onChange(render)

--- a/src/js/transfers/bridged-nep21-to-erc20/index.js
+++ b/src/js/transfers/bridged-nep21-to-erc20/index.js
@@ -94,14 +94,14 @@ export async function checkStatus (transfer) {
     // causes redirect to NEAR Wallet and subsequent update of transfer
     const withdrawal = await withdraw(transfer)
     if (withdrawal.failed) {
-      transfer = storage.update(transfer, {
+      transfer = await storage.update(transfer, {
         status: COMPLETE,
         outcome: FAILED,
         failedAt: WITHDRAWN,
         error: transfer.error
       })
     } else {
-      transfer = storage.update(transfer, {
+      transfer = await storage.update(transfer, {
         ...withdrawal,
         status: WITHDRAWN
       })
@@ -112,13 +112,13 @@ export async function checkStatus (transfer) {
     try {
       const outcomeBlock = await findOutcomeBlock(transfer)
       if (outcomeBlock) {
-        transfer = storage.update(transfer, {
+        transfer = await storage.update(transfer, {
           ...outcomeBlock,
           status: FOUND_OUTCOME
         })
       }
     } catch (error) {
-      transfer = storage.update(transfer, {
+      transfer = await storage.update(transfer, {
         status: COMPLETE,
         outcome: FAILED,
         failedAt: WITHDRAWN,
@@ -131,13 +131,13 @@ export async function checkStatus (transfer) {
     try {
       const ethBlockInfo = await findEthBlock(transfer)
       if (ethBlockInfo) {
-        transfer = storage.update(transfer, {
+        transfer = await storage.update(transfer, {
           ...ethBlockInfo,
           status: FOUND_ETH_BLOCK
         })
       }
     } catch (error) {
-      transfer = storage.update(transfer, {
+      transfer = await storage.update(transfer, {
         status: COMPLETE,
         outcome: FAILED,
         failedAt: FOUND_OUTCOME,
@@ -150,12 +150,12 @@ export async function checkStatus (transfer) {
     try {
       const securityWindowClosed = await checkSecurityWindowClosed(transfer)
       if (securityWindowClosed) {
-        transfer = storage.update(transfer, {
+        transfer = await storage.update(transfer, {
           status: SECURITY_WINDOW_CLOSED
         })
       }
     } catch (error) {
-      transfer = storage.update(transfer, {
+      transfer = await storage.update(transfer, {
         status: COMPLETE,
         outcome: FAILED,
         failedAt: FOUND_ETH_BLOCK,
@@ -167,12 +167,12 @@ export async function checkStatus (transfer) {
   if (transfer.status === SECURITY_WINDOW_CLOSED) {
     try {
       await unlock(transfer)
-      transfer = storage.update(transfer, {
+      transfer = await storage.update(transfer, {
         outcome: SUCCESS,
         status: COMPLETE
       })
     } catch (error) {
-      transfer = storage.update(transfer, {
+      transfer = await storage.update(transfer, {
         status: COMPLETE,
         outcome: FAILED,
         failedAt: SECURITY_WINDOW_CLOSED,
@@ -189,12 +189,12 @@ export async function retry (transfer) {
     case SECURITY_WINDOW_CLOSED:
       try {
         await unlock(transfer)
-        transfer = storage.update(transfer, {
+        transfer = await storage.update(transfer, {
           outcome: SUCCESS,
           status: COMPLETE
         })
       } catch (error) {
-        transfer = storage.update(transfer, {
+        transfer = await storage.update(transfer, {
           status: COMPLETE,
           outcome: FAILED,
           failedAt: SECURITY_WINDOW_CLOSED,

--- a/src/js/transfers/index.js
+++ b/src/js/transfers/index.js
@@ -4,6 +4,8 @@ import * as urlParams from '../urlParams'
 import * as storage from './storage'
 import { COMPLETE } from './statuses'
 
+export { onChange } from './storage'
+
 // Initiate a new transfer of 'amount' tokens. Must provide one of:
 //
 //   • naturalErc20: an address of a natural ERC20 to send to NEAR
@@ -21,7 +23,7 @@ import { COMPLETE } from './statuses'
 //   near-api-js soon.
 // * window.ethUserAddress: address of authenticated Ethereum wallet to send from
 // * window.nearUserAddress: address of authenticated NEAR wallet to send to
-export async function initiate ({ naturalErc20, nep21FromErc20, amount, callback }) {
+export async function initiate ({ naturalErc20, nep21FromErc20, amount }) {
   const originsProvided = [
     naturalErc20,
     nep21FromErc20
@@ -49,18 +51,16 @@ export async function initiate ({ naturalErc20, nep21FromErc20, amount, callback
     ...customAttributes
   }
 
-  track(transfer, callback)
+  track(transfer)
 }
 
 // The only way to retrieve a list of transfers.
 // Returns an object with 'inProgress' and 'complete' keys,
 // and an array of chronologically-ordered transfers for each
-export function get () {
-  const raw = storage.getAll()
-  return Object.keys(raw).sort().reduce(
-    (acc, id) => {
-      const transfer = raw[id]
-
+export async function get () {
+  const transfers = await storage.getAll()
+  return transfers.reduce(
+    (acc, transfer) => {
       if (transfer.status === 'complete') acc.complete.push(transfer)
       else acc.inProgress.push(transfer)
 
@@ -77,9 +77,7 @@ export function humanStatusFor (transfer) {
 }
 
 // Check statuses of all inProgress transfers, and update them accordingly.
-// Accepts an optional callback, which will be called after all transfers have
-// been checked & updated.
-export async function checkStatuses (callback) {
+export async function checkStatuses () {
   // First, check if we've just returned to this page from NEAR Wallet after
   // completing a transfer. Do this outside of main Promise.all to
   //
@@ -87,34 +85,30 @@ export async function checkStatuses (callback) {
   //   2. check retried failed transfers, which are not inProgress
   const id = urlParams.get('minting')
   if (id) {
-    const transfer = storage.get(id)
+    const transfer = await storage.get(id)
     if (transfer && transfer.erc20Address) {
       await naturalErc20ToNep21.checkCompletion(transfer)
     }
     urlParams.clear('minting', 'balanceBefore')
-    if (callback) await callback()
   }
 
-  const { inProgress } = get()
+  const { inProgress } = await get()
 
   // if all transfers successful, nothing to do
   if (!inProgress.length) return
 
-  // Check & update statuses for all in parallel.
-  // Do not pass callback, only call it once after all updated.
+  // Check & update statuses for all in parallel
   await Promise.all(inProgress.map(t => checkStatus(t.id)))
 
-  if (callback) await callback()
-
   // recheck statuses again soon
-  window.setTimeout(() => checkStatuses(callback), 5500)
+  window.setTimeout(() => checkStatuses(), 5500)
 }
 
 // Retry a failed transfer
-export async function retry (id, callback) {
-  let transfer = storage.get(id)
+export async function retry (id) {
+  let transfer = await storage.get(id)
 
-  transfer = storage.update(transfer, {
+  transfer = await storage.update(transfer, {
     status: transfer.failedAt,
     outcome: null,
     error: null,
@@ -129,35 +123,31 @@ export async function retry (id, callback) {
     await bridgedNep21ToErc20.retry(transfer)
   }
 
-  if (callback) await callback()
-  checkStatus(id, callback)
+  checkStatus(id)
 }
 
 // Clear a transfer from localStorage
-export function clear (id) {
-  storage.clear(id)
+export async function clear (id) {
+  await storage.clear(id)
 }
 
 // Add a new transfer to the set of cached local transfers.
 // This transfer will be given a chronologically-ordered id.
-// This transfer will be checked for updates, which, if given a callback, will
-// kick off timed re-checks.
-async function track (transferRaw, callback) {
+// This transfer will be checked for updates on a loop.
+async function track (transferRaw) {
   const id = new Date().toISOString()
   const transfer = { id, ...transferRaw }
 
-  storage.add(transfer)
+  await storage.add(transfer)
 
-  if (callback) await callback()
-  checkStatus(id, callback)
+  checkStatus(id, { loop: true })
 }
 
-// check the status of a single transfer
-// if `callback` is provided:
-//   * it will be called after updating the status in localStorage
-//   * a new call to checkStatus will be scheduled for this transfer, if its status is not SUCCESS
-async function checkStatus (id, callback) {
-  let transfer = storage.get(id)
+// Check the status of a single transfer.
+// If `loop` is provided, a new call to checkStatus will be scheduled for this
+// transfer, if transfer.status is not COMPLETE.
+async function checkStatus (id, { loop = false }) {
+  let transfer = await storage.get(id)
 
   if (transfer.erc20Address) {
     transfer = await naturalErc20ToNep21.checkStatus(transfer)
@@ -167,15 +157,8 @@ async function checkStatus (id, callback) {
     transfer = await bridgedNep21ToErc20.checkStatus(transfer)
   }
 
-  // if successfully transfered, call callback and end
-  if (transfer.status === COMPLETE) {
-    if (callback) await callback()
-    return
-  }
-
-  // if not fully transferred and callback passed in, check status again soon
-  if (callback) {
-    await callback()
-    window.setTimeout(() => checkStatus(transfer.id, callback), 5500)
+  // if not fully transferred and told to loop, check status again soon
+  if (loop && transfer.status !== COMPLETE) {
+    window.setTimeout(() => checkStatus(transfer.id, { loop }), 5500)
   }
 }

--- a/src/js/transfers/storage.js
+++ b/src/js/transfers/storage.js
@@ -1,3 +1,5 @@
+const onChangeFns = []
+
 function localStorageGet (key) {
   try {
     const serializedState = localStorage.getItem(key)
@@ -16,41 +18,54 @@ function localStorageSet (key, state) {
   }
   const serializedState = JSON.stringify(state)
   localStorage.setItem(key, serializedState)
+  Promise.all(onChangeFns.map(fn => fn()))
 }
 
 const STORAGE_KEY = 'rainbow-bridge-transfers'
 
-// Get raw transfers, stored in localStorage as an object indexed by keys
-export function getAll () {
+function getAllRaw () {
   return localStorageGet(STORAGE_KEY) || {}
 }
 
-export function get (id) {
-  if (!id) throw new Error('must provide ID to fetch a single transfer')
-  return getAll()[id]
+// Get raw transfers, stored in localStorage as an object indexed by keys
+export async function getAll () {
+  const raw = getAllRaw()
+  return Object.keys(raw).sort().map(id => raw[id])
 }
 
-export function add (transfer) {
+export async function get (id) {
+  if (!id) throw new Error('must provide ID to fetch a single transfer')
+  return getAllRaw()[id]
+}
+
+export async function add (transfer) {
   localStorageSet(STORAGE_KEY, {
-    ...getAll(),
+    ...getAllRaw(),
     [transfer.id]: transfer
   })
 }
 
 // update a given transfer in localStorage, returning a new object with the
 // updated version
-export function update (transfer, withData) {
+export async function update (transfer, withData) {
   const updatedTransfer = { ...transfer, ...withData }
   localStorageSet(STORAGE_KEY, {
-    ...getAll(),
+    ...getAllRaw(),
     [transfer.id]: updatedTransfer
   })
   return updatedTransfer
 }
 
 // Clear a transfer from localStorage
-export function clear (id) {
-  const transfers = getAll()
+export async function clear (id) {
+  const transfers = getAllRaw()
   delete transfers[id]
   localStorageSet(STORAGE_KEY, transfers)
+}
+
+/**
+ * Add a function to be called any time the data in storage is updated
+ */
+export function onChange (fn) {
+  onChangeFns.push(fn)
 }


### PR DESCRIPTION
This implements the architectural learnings from #55 without yet adding extraneous libraries like PouchDB

BREAKING CHANGES: Requires switching to an async/await approach when calling `transfers.get` or `transfers.clear`. Removes `callback` attribute from all `transfers` functions; use `transfers.onChange` instead.