### PR TITLE
feat: document transfers library-to-be

### DIFF
--- a/src/js/transfers/README.md
+++ b/src/js/transfers/README.md
@@ -1,0 +1,247 @@
+`@eth~near/core` – the Rainbow Bridge client library 🌈🌉
+====================================================
+
+Do you want to allow your users to send assets between [Ethereum] & [NEAR] over
+the [Rainbow Bridge]?
+
+Do you want to easily send assets between the two blockchains using your
+command line?
+
+Did you build a custom Rainbow Bridge [Connector] and now you want to figure
+out how to build a client library for it, so other people can actually use it?
+
+If you answered "Yes" to any of the above questions, this is the library for you!
+
+  [Ethereum]: https://ethereum.org/
+  [NEAR]: https://near.org/
+  [Rainbow Bridge]: https://near.org/blog/eth-near-rainbow-bridge/
+  [Connector]: https://github.com/near/rainbow-token-connector
+
+Read on to find out how to:
+
+- [Add it to your browser app](#add-it-to-your-browser-app)
+- [Author a custom connector library](#author-a-custom-connector-library)
+
+
+Add it to your browser app
+==========================
+
+Let's say you want to allow users to send ERC20 tokens from Ethereum to NEAR,
+where they'll become NEP21 tokens.
+
+Step 1: Add Dependencies
+------------------------
+
+You'll need to add two dependencies to your app:
+
+    npm install --save @eth~near/core @eth~near/erc20~nep21
+
+Alternatively, if using yarn:
+
+    yarn add @eth~near/core @eth~near/erc20~nep21
+
+Step 2: Initiate a transfer
+---------------------------
+
+Let's say you have a form.
+
+```js
+<form>
+  <input id="erc20Address" />
+  <input id="amount" />
+  <input id="sender" />
+  <input id="recipient" />
+</form>
+```
+
+Here's the JavaScript you'll want to make this work:
+
+```js
+import { naturalErc20ToNep21 } from '@eth~near/erc20~nep21'
+
+document.querySelector('form').onsubmit = e => {
+  e.preventDefault()
+  const { erc20Address, amount, sender, recipient } = e.target.elements
+  naturalErc20ToNep21({
+    erc20Address: erc20Address.value,
+    amount: amount.value,
+    sender: sender.value,
+    recipient: recipient.value,
+  })
+}
+```
+
+What is `@eth~near/erc20~nep21`?
+
+The Rainbow Bridge between Ethereum and NEAR has [many pieces][Rainbow Bridge].
+One piece is **Connector** contracts. The connector code for converting ERC20
+tokens in Ethereum to NEP21 tokens in NEAR lives at
+[github.com/near/rainbow-token-connector][Connector].
+
+The code for using a given connector from an app has its own library. The one
+for the connector above is [`@eth~near/erc20~nep21`].
+
+Anyone can make connector contracts, and anyone can make client libraries for
+these contracts. If they follow the format of `@eth~near/erc20~nep21`, these
+client libraries will work automatically with the core Rainbow Bridge transfer
+library at `@eth~near/core`.
+
+Generally, each connector client library, like `@eth~near/erc20~nep21`, will
+export four main functions, which can be used to:
+
+1. Go from a "natural" Ethereum token to a "bridged" NEAR equivalent
+2. Go from a "bridged" NEAR token, meaning a token that started its life in
+   Ethereum but which now lives in NEAR, back to Ethereum
+3. Go from a natural NEAR token to a bridged Ethereum equivalent
+4. Go from a bridged Ethereum token back to NEAR
+
+For `@eth~near/erc20~nep21`, these main exports are:
+
+1. `naturalErc20ToNep21` – example: go from DAI (a popular ERC20 token) to DAIⁿ
+2. `bridgedNep21ToErc20` – example: convert DAIⁿ back to DAI
+3. `naturalNep21ToErc20` – example: go from a natural NEAR token, such as BNNA
+   Tokens in berryclub.io, to BNNAᵉ in Ethereum
+4. `bridgedErc20ToNep21` – example: convert BNNAᵉ back to BNNA
+
+
+Step 3: List in-progress transfers
+----------------------------------
+
+For the rest of the lifetime of the transfer you just initiated, you will use
+exports from `@eth~near/core`, rather than the connector-specific library.
+
+Let's say you want to list in-progress transfers in this `ol`:
+
+```js
+<ol id="transfers-go-here"></ol>
+```
+
+Here's code to render the list of transfers:
+
+```js
+import { get, onChange } from '@eth~near/core'
+
+function renderTransfers () {
+  const transfers = get({ filter: { status: 'in-progress' } })
+  document.querySelector('#transfers-go-here').innerHTML =
+    transfers.map(renderTransfer).join('')
+}
+
+onChange(renderTransfers)
+
+renderTransfers()
+```
+
+If using React, you'd want something like:
+
+```jsx
+TODO
+```
+
+And here's what `renderTransfer` might look like, using vanilla JS (translation
+to React is straightforward):
+
+```js
+import { act, decorate } from '@eth~near/core'
+
+function renderTransfer (transfer) {
+  // "decorate" transfer with realtime info & other data that would bloat localStorage
+  transfer = decorate(transfer, { locale: 'en_US' })
+  return `
+    <li class="transfer" id="${transfer.id}">
+      ${transfer.amount}
+      ${transfer.sourceTokenName} from
+      ${transfer.sender} to
+      ${transfer.recipient}
+      ${(transfer.status === 'failed' || transfer.status === 'action-needed' ? (
+        <button class="act-on-transfer">
+          ${transfer.callToAction}
+        </button>
+      ) : '')}
+    </li>
+  `
+})
+
+// Vanilla JS shenanigans: add a click handler to `body`, because transfers are
+// rendered with JS and therefore unavailable for adding click handlers at
+// initial page load.
+// This will be easier if you use React or something 😄
+document.querySelector('body').addEventListener('click', event => {
+  const callToAction = event.target.closest('.act-on-transfer')
+  if (callToAction) {
+    const transferId = callToAction.closest('.transfer').id
+    act(transferId)
+  }
+})
+```
+
+Here's some [docs about act][act], and [two][act2] [example][act3]
+connector-specific behaviors. Here's some [docs about decorate][decorate], and
+[two][decorate2] [example][decorate3] connector-specific behaviors. Here's the
+attributes for [two][initiate-natural] [kinds][initiate-bridged] of raw
+transfers, prior to being decorated.
+
+  [act]: https://github.com/near/rainbow-bridge-frontend/blob/bfcd96178316f840845217371bebd253cc64abd1/src/js/transfers/index.js#L132-L140
+  [act2]: https://github.com/near/rainbow-bridge-frontend/blob/bfcd96178316f840845217371bebd253cc64abd1/src/js/transfers/erc20%2Bnep21/natural-erc20-to-nep21/index.js#L62-L69
+  [act3]: https://github.com/near/rainbow-bridge-frontend/blob/bfcd96178316f840845217371bebd253cc64abd1/src/js/transfers/erc20%2Bnep21/bridged-nep21-to-erc20/index.js#L67-L73
+  [decorate]: https://github.com/near/rainbow-bridge-frontend/blob/bfcd96178316f840845217371bebd253cc64abd1/src/js/transfers/index.js#L46-L68
+  [decorate2]: https://github.com/near/rainbow-bridge-frontend/blob/bfcd96178316f840845217371bebd253cc64abd1/src/js/transfers/erc20%2Bnep21/natural-erc20-to-nep21/index.js#L19-L59
+  [decorate3]: https://github.com/near/rainbow-bridge-frontend/blob/bfcd96178316f840845217371bebd253cc64abd1/src/js/transfers/erc20%2Bnep21/bridged-nep21-to-erc20/index.js#L21-L64
+  [initiate-natural]: https://github.com/near/rainbow-bridge-frontend/blob/bfcd96178316f840845217371bebd253cc64abd1/src/js/transfers/erc20%2Bnep21/natural-erc20-to-nep21/index.js#L97-L117
+  [initiate-bridged]: https://github.com/near/rainbow-bridge-frontend/blob/bfcd96178316f840845217371bebd253cc64abd1/src/js/transfers/erc20%2Bnep21/bridged-nep21-to-erc20/index.js#L98-L121
+
+
+Step 4: check & update status of in-progress transfers
+------------------------------------------------------
+
+Your app will need to prompt users to sign in with both Ethereum
+([example][authEthereum]) and NEAR ([example][authNear]). After the
+authorization process completes for both chains, you need this:
+
+```js
+import { checkStatusAll } from '@eth~near/core'
+
+checkStatusAll({ loop: 15000 })
+```
+
+What's it do?
+
+This library is designed to be non-blocking, which means a user can start
+multiple transfers at once, and the library won't pause to wait for blocks to
+be mined in Ethereum, finalized in NEAR, or synced between the two.
+
+This means that with only the code from Steps 1-3, nothing else will happen. A
+user will have sent an initial transaction to the Ethereum or NEAR blockchain,
+but neither your app nor any other service will ever check to see if that
+transaction completes successfully. Nor will any app or service prompt the user
+to complete the next transaction in the process (any transfer requires multiple
+steps & multiple on-chain transactions to complete).
+
+`checkStatusAll` will loop as frequently as you tell it to. It will check to
+see if transactions have been mined, synced, or finalized, and update transfers
+in localStorage accordingly. When transfers are updated, the `onChange`
+function in Step 3 will trigger a UI update.
+
+  [authEthereum]: https://github.com/near/rainbow-bridge-frontend/blob/bfcd96178316f840845217371bebd253cc64abd1/src/js/authEthereum.js
+  [authNear]: https://github.com/near/rainbow-bridge-frontend/blob/bfcd96178316f840845217371bebd253cc64abd1/src/js/authNear.js
+
+
+Step 5: there is no step 5!
+---------------------------
+
+That's it! You successfully integrated cross-chain transfers into your app in
+just four steps. 🌈🌉🎉
+
+To make it more beautiful, check out [the API docs](#TODO🙃) and [example
+code][example] (implemented in vanilla/no-framework JavaScript).
+
+  [example]: https://github.com/near/rainbow-bridge-frontend/blob/bfcd96178316f840845217371bebd253cc64abd1/src/html/transfers.html#L339-L388
+
+
+Author a custom connector library
+=================================
+
+1. Copy the code in the [`@eth~near/erc20~nep21`] library
+2. Adjust for your needs
+
+  [`@eth~near/erc20~nep21`]: https://github.com/near/rainbow-bridge-frontend/tree/526ed49248974e38b438d92c12ede1b6305eb869/src/js/transfers/erc20%2Bnep21


### PR DESCRIPTION
See README for an explanation of how to use the current library. I would love critical feedback on how to improve both library design and documentation.

Caveats: the code in the `transfers` directory here still has many dependencies on items that I add to `window` when users authenticate with [Ethereum](https://github.com/near/rainbow-bridge-frontend/blob/330d105bef0313cd8ccbc92ba4a821f8702f90c1/src/js/authEthereum.js) & [NEAR](https://github.com/near/rainbow-bridge-frontend/blob/330d105bef0313cd8ccbc92ba4a821f8702f90c1/src/js/authNear.js). It also still has some unresolved [TODO comments](https://github.com/near/rainbow-bridge-frontend/blob/330d105bef0313cd8ccbc92ba4a821f8702f90c1/src/js/transfers/index.js#L1). **The README added here is therefore best-case.** The final library design may require some extra steps, pending the result of further research into how to extricate the code from the specifics of this app.

Onward:


Naming the orgs
---------------

One of the biggest areas I think we need to clear up is what to name the libraries, starting with the NPM & GitHub organizations.

I anticipate us having many packages & repositories for the Rainbow Bridge. We could name the organizations `rainbow-bridge`, but I see three downsides:

1. It's a little long
2. It's overly cute/branded for this use-case; I'd prefer something that's legible/guessable/straightforward. There's enough cute/insider lingo to figure out in this space; this can be one place we ease developers' mental overhead rather than add to it.
3. If we eventually make bridges between NEAR & other chains, do those packages need their own cute/branded name? Or do we lump it all under the same orgs, ending up with things like `rainbow-bridge/eth-near-core`, `rainbow-bridge/polkadot-near-core`, etc? Ew. Either way, ew.

Instead, I suggest we name the organizations `eth~near`. Why `~`?

* It's one of the few [URL-safe](https://perishablepress.com/stop-using-unsafe-characters-in-urls/) charaters that NPM will let us use
* It's eye-catching & fairly descriptive, for a glyph (It looks like a whimsical bridge?)
* It's not a dash, which is commonplace and fails to provide visual separation between the "eth" and "near"


How the libs will work together
-------------------------------

If we go with that, then here's what a `package.json` might look like for an app that wants to bridge a few kinds of tokens between Ethereum & NEAR:

```json
"dependencies": {
  "@eth~near/core": "*",
  "@eth~near/erc20~nep141": "*",
  "@eth~near/erc721~nep4": "*",
  "some-3rd-party-connector-lib": "*"
}
```

The `@eth~near/core` here represents the core library for which I've added a README in this PR.

**Should this be called `core`?** It seems like maybe we'll want to reserve that name for [near/rainbow-bridge](https://github.com/near/rainbow-bridge).

If we call this one something else, what should it be called? `@eth~near/client`?


How this core/client library works
----------------------------------

In any case, here are the design goals of the main library I've documented here:

* Allow anyone else to permissionlessly create & publish their own connector-specific libraries which seamlessly interoperate with our own
* Enable easy integration of Rainbow Bridge tech in any frontend stack (it was designed around the needs of a vanilla/no-framework JS app, which will allow for easy & minimal modifications to make it work with React and other popular libraries)


How it will work with NodeJS
----------------------------

Two main modifications are needed before these libraries will work with NodeJS (and hence a command line interface):

1. Wrap `localStorage` with something like [node-localstorage](https://www.npmjs.com/package/node-localstorage) (see https://github.com/near/near-api-js/pull/467 for an example of how this might work). The [storage](https://github.com/near/rainbow-bridge-frontend/blob/330d105bef0313cd8ccbc92ba4a821f8702f90c1/src/js/transfers/storage.js) implementation already uses async/await for all exports, which allows us to more easily consider a variety of modifications.
2. Complete https://github.com/near/near-api-js/pull/467 so that we can get rid of browser-specific things like [setting the URL to deal with redirects to NEAR Wallet](https://github.com/near/rainbow-bridge-frontend/blob/330d105bef0313cd8ccbc92ba4a821f8702f90c1/src/js/transfers/erc20%2Bnep21/natural-erc20-to-nep21/index.js#L255)

From there, we still have some work to do to design the CLI we want. I haven't mapped it out extensively, but I envision the simplest use-case for users being interactive, with steps roughly similar to those seen in [the UI](https://near.github.io/rainbow-bridge-frontend/). Such an approach may request or even require user input at each of the "action needed" steps (all the times transfers turn blue in the UI). If an advanced user wants to complete an entire transfer without interactivity, this would be possible by passing more options to the initial command and/or piping [yes](https://man7.org/linux/man-pages/man1/yes.1.html) into the script.