### PR TITLE
fix: update token balances without page refresh

### DIFF
--- a/src/html/erc20-form.html
+++ b/src/html/erc20-form.html
@@ -161,9 +161,6 @@
   async function fillFeaturedErc20s () {
     if (!window.ethInitialized) return
 
-    // only fill once
-    if (window.state.erc20ListFilled) return
-
     const featured = await window.utils.getFeaturedErc20s()
 
     window.dom.fill('erc20List').with(
@@ -185,8 +182,6 @@
         </label>
       `)
     )
-
-    window.state.erc20ListFilled = true
   }
 
   let erc20Address

--- a/src/html/erc20n-form.html
+++ b/src/html/erc20n-form.html
@@ -163,9 +163,6 @@
   async function fillFeaturedErc20ns () {
     if (!window.ethInitialized) return
 
-    // only fill once
-    if (window.state.erc20nListFilled) return
-
     const featured = await window.utils.getFeaturedErc20s()
 
     window.dom.fill('erc20nList').with(
@@ -187,8 +184,6 @@
         </label>
       `)
     )
-
-    window.state.erc20nListFilled = true
   }
 
   let erc20nAddress

--- a/src/js/transfers/nep141~erc20/natural-erc20/getMetadata.js
+++ b/src/js/transfers/nep141~erc20/natural-erc20/getMetadata.js
@@ -19,7 +19,7 @@ async function getBalance (address, user) {
 
 const erc20Decimals = {}
 async function getDecimals (address) {
-  if (erc20Decimals[address]) return erc20Decimals[address]
+  if (erc20Decimals[address] !== undefined) return erc20Decimals[address]
 
   const web3 = new Web3(getEthProvider())
 
@@ -39,7 +39,7 @@ async function getDecimals (address) {
 
 const erc20Icons = {}
 async function getIcon (address) {
-  if (erc20Icons[address]) return erc20Icons[address]
+  if (erc20Icons[address] !== undefined) return erc20Icons[address]
 
   const url = `https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/${address}/logo.png`
   erc20Icons[address] = await new Promise(resolve => {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -14,13 +14,10 @@ export async function getErc20Data (address) {
   return { ...erc20, nep141 }
 }
 
-let featuredErc20s
 export async function getFeaturedErc20s () {
-  if (featuredErc20s) return featuredErc20s
-
   const ethNetwork = await window.web3.eth.net.getNetworkType()
 
-  featuredErc20s = (await Promise.all(
+  return (await Promise.all(
     JSON.parse(process.env.featuredErc20s)[ethNetwork].map(getErc20Data)
   )).reduce(
     (acc, token) => {
@@ -29,5 +26,4 @@ export async function getFeaturedErc20s () {
     },
     {}
   )
-  return featuredErc20s
 }


### PR DESCRIPTION
The list of ERC20 tokens and the list of associated bridged NEP141 variants was only rendered once, at page load. This meant that if you started a transfer of a certain number of tokens then started a new transfer, you would see your old balance in the token-select modals.

This fixes some caching issues in the getMetadata helpers to efficiently re-render the tokens on every `render` call.