### PR TITLE
fix: support big number transfer amounts

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@walletconnect/web3-provider": "^1.2.1",
     "bs58": "^4.0.1",
+    "decimal.js": "^10.2.1",
     "eth-object": "near/eth-object#54e03b8aac8208cf724e206d49ffb8bdd30451d7",
     "eth-revert-reason": "^1.0.3",
     "eth-util-lite": "near/eth-util-lite#master",

--- a/src/html/erc20-form.html
+++ b/src/html/erc20-form.html
@@ -127,7 +127,6 @@
 
       try {
         await window.nep141Xerc20.naturalErc20.sendToNear({
-          // TODO fix for non-integers
           amount: amount.value,
           erc20Address: window.dom.find('erc20Address').value,
           sender: window.ethUserAddress,
@@ -177,7 +176,7 @@
             ${token.name}
           </span>
           <span>
-            ${window.utils.formatLargeNum(token.balance)}
+            ${window.utils.formatLargeNum(token.balance, token.decimals)}
           </span>
         </label>
       `)
@@ -238,9 +237,9 @@
 
     window.dom.show('sendNaturalErc20')
 
-    window.dom.fill('erc20Balance').with(window.utils.formatLargeNum(token.balance))
+    window.dom.fill('erc20Balance').with(window.utils.formatLargeNum(token.balance, token.decimals))
     window.dom.fill('nep141Name').with(token.nep141.name)
-    window.dom.fill('nep141Balance').with(window.utils.formatLargeNum(token.nep141.balance))
+    window.dom.fill('nep141Balance').with(window.utils.formatLargeNum(token.nep141.balance, token.decimals))
 
     if (token.balance) amount.disabled = false
     else amount.disabled = true

--- a/src/html/erc20-form.html
+++ b/src/html/erc20-form.html
@@ -128,7 +128,7 @@
       try {
         await window.nep141Xerc20.naturalErc20.sendToNear({
           // TODO fix for non-integers
-          amount: Number(amount.value),
+          amount: amount.value,
           erc20Address: window.dom.find('erc20Address').value,
           sender: window.ethUserAddress,
           recipient: window.nearUserAddress

--- a/src/html/erc20n-form.html
+++ b/src/html/erc20n-form.html
@@ -130,7 +130,7 @@
 
       try {
         await window.nep141Xerc20.bridgedNep141.sendToEthereum({
-          amount: Number(amount.value),
+          amount: amount.value,
           erc20Address: window.urlParams.get('erc20n'),
           sender: window.nearUserAddress,
           recipient: window.ethUserAddress
@@ -179,7 +179,7 @@
             ${token.nep141.name}
           </span>
           <span>
-            ${window.utils.formatLargeNum(token.nep141.balance)}
+            ${window.utils.formatLargeNum(token.nep141.balance, token.decimals)}
           </span>
         </label>
       `)
@@ -238,10 +238,10 @@
 
     window.dom.fill('erc20nName').with(token.nep141.name)
     window.dom.fill('erc20nBalance').with(
-      window.utils.formatLargeNum(token.nep141.balance)
+      window.utils.formatLargeNum(token.nep141.balance, token.decimals)
     )
     window.dom.fill('erc20Balance').with(
-      window.utils.formatLargeNum(token.balance)
+      window.utils.formatLargeNum(token.balance, token.decimals)
     )
 
     window.dom.show('sendBridgedNep141')

--- a/src/html/transfers.html
+++ b/src/html/transfers.html
@@ -346,7 +346,7 @@ function renderTransfer (transfer, { inProgress }) {
     >
       <header>
         <div>
-          <h3>${transfer.amount} ${transfer.sourceTokenName}</h3>
+          <h3>${window.utils.formatLargeNum(transfer.amount, transfer.naturalDecimals)} ${transfer.sourceTokenName}</h3>
           <div class="status-message">
             <span class="icon"></span>
             <span>${transfer.statusMessage}</span>

--- a/src/html/transfers.html
+++ b/src/html/transfers.html
@@ -346,7 +346,7 @@ function renderTransfer (transfer, { inProgress }) {
     >
       <header>
         <div>
-          <h3>${window.utils.formatLargeNum(transfer.amount, transfer.naturalDecimals)} ${transfer.sourceTokenName}</h3>
+          <h3>${window.utils.formatLargeNum(transfer.amount, transfer.decimals)} ${transfer.sourceTokenName}</h3>
           <div class="status-message">
             <span class="icon"></span>
             <span>${transfer.statusMessage}</span>

--- a/src/js/transfers/nep141~erc20/bridged-nep141/getBalance.js
+++ b/src/js/transfers/nep141~erc20/bridged-nep141/getBalance.js
@@ -22,7 +22,7 @@ export default async function getBalance ({ erc20Address, user }) {
       'get_balance',
       { owner_id: user }
     )
-    return Number(balanceAsString)
+    return balanceAsString
   } catch (e) {
     console.warn(e)
     return null

--- a/src/js/transfers/nep141~erc20/bridged-nep141/sendToEthereum/index.js
+++ b/src/js/transfers/nep141~erc20/bridged-nep141/sendToEthereum/index.js
@@ -34,10 +34,10 @@ const steps = [
 export const i18n = {
   en_US: {
     steps: transfer => stepsFor(transfer, steps, {
-      [WITHDRAW]: `Withdraw ${formatLargeNum(transfer.amount, transfer.naturalDecimals)} ${transfer.sourceTokenName} from NEAR`,
+      [WITHDRAW]: `Withdraw ${formatLargeNum(transfer.amount, transfer.decimals)} ${transfer.sourceTokenName} from NEAR`,
       [AWAIT_FINALITY]: 'Await NEAR finality for withdrawal transaction',
       [SYNC]: 'Sync withdrawal transaction to Ethereum',
-      [UNLOCK]: `Unlock ${formatLargeNum(transfer.amount, transfer.naturalDecimals)} ${transfer.destinationTokenName} in Ethereum`
+      [UNLOCK]: `Unlock ${formatLargeNum(transfer.amount, transfer.decimals)} ${transfer.destinationTokenName} in Ethereum`
     }),
     statusMessage: transfer => {
       if (transfer.status === status.FAILED) return 'Failed'
@@ -93,16 +93,15 @@ export async function initiate ({
 }) {
   // TODO: move to core 'decorate'; get both from contracts
   const destinationTokenName = await getErc20Name(erc20Address)
-  // NOTE getDecimals is needed here so it can't be used as a decorator
-  // like getErc20Name
-  const naturalDecimals = await getDecimals(erc20Address)
+  // TODO: call initiate with a formated amount and query decimals when decorate()
+  const decimals = await getDecimals(erc20Address)
   const sourceTokenName = destinationTokenName + 'ⁿ'
   const sourceToken = getNep141Address(erc20Address)
 
   // various attributes stored as arrays, to keep history of retries
   const transfer = {
     // attributes common to all transfer types
-    amount: (new Decimal(amount).times(10 ** naturalDecimals)).toString(),
+    amount: (new Decimal(amount).times(10 ** decimals)).toString(),
     completedStep: null,
     destinationTokenName,
     errors: [],
@@ -110,7 +109,7 @@ export async function initiate ({
     sender,
     sourceToken,
     sourceTokenName,
-    naturalDecimals,
+    decimals,
     status: status.IN_PROGRESS,
     type: TRANSFER_TYPE,
 

--- a/src/js/transfers/nep141~erc20/natural-erc20/getMetadata.js
+++ b/src/js/transfers/nep141~erc20/natural-erc20/getMetadata.js
@@ -16,7 +16,7 @@ async function getBalance (address, user) {
 }
 
 const erc20Decimals = {}
-async function getDecimals (address) {
+export async function getDecimals (address) {
   if (erc20Decimals[address] !== undefined) return erc20Decimals[address]
 
   const web3 = new Web3(getEthProvider())

--- a/src/js/transfers/nep141~erc20/natural-erc20/getMetadata.js
+++ b/src/js/transfers/nep141~erc20/natural-erc20/getMetadata.js
@@ -12,9 +12,7 @@ async function getBalance (address, user) {
     address
   )
 
-  return Number(
-    await erc20Contract.methods.balanceOf(user).call()
-  )
+  return await erc20Contract.methods.balanceOf(user).call()
 }
 
 const erc20Decimals = {}

--- a/src/js/transfers/nep141~erc20/natural-erc20/sendToNear/index.js
+++ b/src/js/transfers/nep141~erc20/natural-erc20/sendToNear/index.js
@@ -33,10 +33,10 @@ const steps = [
 export const i18n = {
   en_US: {
     steps: transfer => stepsFor(transfer, steps, {
-      [APPROVE]: `Approve Token Locker to spend ${formatLargeNum(transfer.amount, transfer.naturalDecimals)} ${transfer.sourceTokenName}`,
-      [LOCK]: `Lock ${formatLargeNum(transfer.amount, transfer.naturalDecimals)} ${transfer.sourceTokenName} in Token Locker`,
+      [APPROVE]: `Approve Token Locker to spend ${formatLargeNum(transfer.amount, transfer.decimals)} ${transfer.sourceTokenName}`,
+      [LOCK]: `Lock ${formatLargeNum(transfer.amount, transfer.decimals)} ${transfer.sourceTokenName} in Token Locker`,
       [SYNC]: `Sync ${transfer.neededConfirmations} blocks from Ethereum to NEAR`,
-      [MINT]: `Mint ${formatLargeNum(transfer.amount, transfer.naturalDecimals)} ${transfer.destinationTokenName} in NEAR`
+      [MINT]: `Mint ${formatLargeNum(transfer.amount, transfer.decimals)} ${transfer.destinationTokenName} in NEAR`
     }),
     statusMessage: transfer => {
       if (transfer.status === status.FAILED) return 'Failed'
@@ -100,15 +100,14 @@ export async function initiate ({
 }) {
   // TODO: move to core 'decorate'; get both from contracts
   const sourceTokenName = await getName(erc20Address)
-  // NOTE getDecimals is needed here so it can't be used as a decorator
-  // like getErc20Name
-  const naturalDecimals = await getDecimals(erc20Address)
+  // TODO: call initiate with a formated amount and query decimals when decorate()
+  const decimals = await getDecimals(erc20Address)
   const destinationTokenName = sourceTokenName + 'ⁿ'
 
   // various attributes stored as arrays, to keep history of retries
   let transfer = {
     // attributes common to all transfer types
-    amount: (new Decimal(amount).times(10 ** naturalDecimals)).toString(),
+    amount: (new Decimal(amount).times(10 ** decimals)).toString(),
     completedStep: null,
     destinationTokenName,
     errors: [],
@@ -116,7 +115,7 @@ export async function initiate ({
     sender,
     sourceToken: erc20Address,
     sourceTokenName,
-    naturalDecimals,
+    decimals,
     status: status.ACTION_NEEDED,
     type: TRANSFER_TYPE,
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,9 +1,11 @@
 import { bridgedNep141, naturalErc20 } from './transfers/nep141~erc20'
 
 export function formatLargeNum (n) {
-  if (!n) return 0
-  if (n >= 1e5 || (n < 1e-3 && n !== 0)) return n.toExponential()
-  return new Intl.NumberFormat(undefined, { maximumSignificantDigits: 5 }).format(n)
+  // TODO abstract decimals for the user
+  // if (!n) return 0
+  // if (n >= 1e5 || (n < 1e-3 && n !== 0)) return n.toExponential()
+  // return new Intl.NumberFormat(undefined, { maximumSignificantDigits: 5 }).format(n)
+  return n
 }
 
 export async function getErc20Data (address) {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -2,9 +2,9 @@ import { bridgedNep141, naturalErc20 } from './transfers/nep141~erc20'
 
 import { Decimal } from 'decimal.js'
 
-export function formatLargeNum (n, naturalDecimals = 18) {
-  // naturalDecimals defaults to 18 for old transfers in state that didn't record transfer.naturalDecimals
-  return new Decimal(n).dividedBy(10 ** naturalDecimals)
+export function formatLargeNum (n, decimals = 18) {
+  // decimals defaults to 18 for old transfers in state that didn't record transfer.decimals
+  return new Decimal(n).dividedBy(10 ** decimals)
 }
 
 export async function getErc20Data (address) {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,11 +1,10 @@
 import { bridgedNep141, naturalErc20 } from './transfers/nep141~erc20'
 
-export function formatLargeNum (n) {
-  // TODO abstract decimals for the user
-  // if (!n) return 0
-  // if (n >= 1e5 || (n < 1e-3 && n !== 0)) return n.toExponential()
-  // return new Intl.NumberFormat(undefined, { maximumSignificantDigits: 5 }).format(n)
-  return n
+import { Decimal } from 'decimal.js'
+
+export function formatLargeNum (n, naturalDecimals = 18) {
+  // naturalDecimals defaults to 18 for old transfers in state that didn't record transfer.naturalDecimals
+  return new Decimal(n).dividedBy(10 ** naturalDecimals)
 }
 
 export async function getErc20Data (address) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4007,6 +4007,11 @@ decamelize@^1.1.0, decamelize@^1.1.1, decamelize@^1.2.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
 
+decimal.js@^10.2.1:
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.2.1.tgz#238ae7b0f0c793d3e3cea410108b35a2c01426a3"
+  integrity sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==
+
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"


### PR DESCRIPTION
Fix for issues #78, #79 and #91
Users can now enter any number of tokens (including floats) and the correct decimals will be applied (usually 18 but often not the case for stable coins and others)