### PR TITLE
fix: improve error msg when sendToNear fails + Rinkeby config

### DIFF
--- a/.config.js
+++ b/.config.js
@@ -42,14 +42,39 @@ module.exports = {
 
     // frontend settings
     featuredErc20s: JSON.stringify([
-        '0x722dd3F80BAC40c951b51BdD28Dd19d435762180', // TST: https://ropsten.etherscan.io/address/0x722dd3f80bac40c951b51bdd28dd19d435762180
-        '0xFab46E002BbF0b4509813474841E0716E6730136', // FAU: https://ropsten.etherscan.io/token/0xfab46e002bbf0b4509813474841e0716e6730136
-        '0xbF4D811e6891eD044D245cafcC4CAa96c969204D', // USDT: https://ropsten.etherscan.io/token/0xbf4d811e6891ed044d245cafcc4caa96c969204d
-      ]),
+      '0x722dd3F80BAC40c951b51BdD28Dd19d435762180', // TST: https://ropsten.etherscan.io/address/0x722dd3f80bac40c951b51bdd28dd19d435762180
+      '0xFab46E002BbF0b4509813474841E0716E6730136', // FAU: https://ropsten.etherscan.io/token/0xfab46e002bbf0b4509813474841e0716e6730136
+      '0xbF4D811e6891eD044D245cafcC4CAa96c969204D', // USDT: https://ropsten.etherscan.io/token/0xbf4d811e6891ed044d245cafcc4caa96c969204d
+    ]),
     nearNodeUrl: 'https://rpc.testnet.near.org',
     nearWalletUrl: 'https://wallet.testnet.near.org',
     nearExplorerUrl: 'https://explorer.testnet.near.org',
     nearNetworkId: 'testnet',
     ethNetworkId: 'ropsten',
   },
+  rinkeby_development: {
+    // library settings
+    ethClientAddress: '0x067421d6ba15d5c70190a1e512c5f9137a4a8168',
+    ethNearOnEthClientAbiText: readFileSync('./abi/nearOnEthClient.abi'),
+    ethEd25519Address: '0xa9e58bed3649e535dba9fa594e67e39575db3f4b',
+    ethErc20AbiText: readFileSync('./abi/erc20.abi'),
+    ethLockerAbiText: readFileSync('./node_modules/rainbow-token-connector/res/BridgeTokenFactory.full.abi'),
+    ethLockerAddress: '0x6381a3bad6b51988497dc588496ad1177d1650ea',
+    ethProverAddress: '0x57d7dc68f98bd09b8d1ea46aac61c305f203f104',
+    ethProverAbiText: readFileSync('./abi/prover.abi'),
+    nearClientAccount: 'client.rinkeby.testnet',
+    nearHelperUrl: 'https://helper.testnet.near.org',
+    nearProverAccount: 'prover.rinkeby.testnet',
+    nearTokenFactoryAccount: 'f030221.rinkeby.testnet',
+
+    // frontend settings
+    featuredErc20s: JSON.stringify([
+      '0x3e13318e92F0C67Ca10f0120372E998d43E6a8E8', // ABND: https://github.com/chadoh/abundance-token
+    ]),
+    nearNodeUrl: 'https://rpc.testnet.near.org',
+    nearWalletUrl: 'https://wallet.testnet.near.org',
+    nearExplorerUrl: 'https://explorer.testnet.near.org',
+    nearNetworkId: 'testnet',
+    ethNetworkId: 'rinkeby',
+  }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@near-eth/client": "^0.2.1",
-    "@near-eth/nep141-erc20": "^0.2.2",
+    "@near-eth/nep141-erc20": "^0.2.4",
     "@walletconnect/web3-provider": "^1.2.1",
     "bs58": "^4.0.1",
     "decimal.js": "^10.2.1",

--- a/src/html/erc20-form.html
+++ b/src/html/erc20-form.html
@@ -133,9 +133,8 @@
         })
       } catch (e) {
         alert(
-          'Something went wrong! ' +
-          'Maybe you need to sign out and back in? ' +
-          'Check your browser console for more info.'
+          'Something went wrong!\n' +
+          e.message
         )
         throw e
       } finally {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,10 +1281,10 @@
     decimal.js "^10.2.1"
     near-api-js near/near-api-js#account-type-fixes
 
-"@near-eth/nep141-erc20@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@near-eth/nep141-erc20/-/nep141-erc20-0.2.2.tgz#5fd0b82ec75633b55f4b1bc5d5116c52b2958f39"
-  integrity sha512-8Ip57HHFS5S2QfANAxps6n1YqqdohER2jV77aP8dP54IQPJyEIJ3QACqXzJuzfmWBDeiJeezbcGW9FGugbLRQA==
+"@near-eth/nep141-erc20@^0.2.4":
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/@near-eth/nep141-erc20/-/nep141-erc20-0.2.4.tgz#36f717f692f0173aa4bc9a7bc90fd2611a1a59ed"
+  integrity sha512-qWtBqQ0k8Zhb74tSw36rvnNO6qA14kdolXIrbRK+tjDBTQpTYB/3L5ZUP4hcQ7TiGHtrCFJzGK2nlwqz4JY+4w==
   dependencies:
     "@near-eth/client" "0.2.1"
     bn.js "^5.1.3"


### PR DESCRIPTION
Fix for displaying the error message from `sendToNear` in case of error: when there is already one pending transfer that is not locked (https://github.com/near/rainbow-bridge-client/pull/3) or when the user rejects signing in metamask.
@chadoh is there still a case where signing out and back in might be required ?