### PR TITLE
fix: don't query metadata (render) if wrong eth network

### DIFF
--- a/src/html/bridge-erc20-form.html
+++ b/src/html/bridge-erc20-form.html
@@ -44,6 +44,7 @@
 
   async function renderBridgeErc20 () {
     if (!(window.ethInitialized && window.nearInitialized)) return
+    if (!window.isValidEthNetwork) return
 
     const { erc20, erc20n } = window.urlParams.get('erc20', 'erc20n')
     const erc20Address = erc20 || erc20n

--- a/src/html/erc20-form.html
+++ b/src/html/erc20-form.html
@@ -157,6 +157,7 @@
 
   async function fillFeaturedErc20s () {
     if (!window.ethInitialized) return
+    if (!window.isValidEthNetwork) return
 
     const featured = await window.utils.getFeaturedErc20s()
 
@@ -184,6 +185,7 @@
   let erc20Address
   async function renderErc20Form () {
     if (!(window.ethInitialized && window.nearInitialized)) return
+    if (!window.isValidEthNetwork) return
 
     if (window.urlParams.get('erc20') === erc20Address) return
     else erc20Address = window.urlParams.get('erc20')

--- a/src/html/erc20n-form.html
+++ b/src/html/erc20n-form.html
@@ -159,6 +159,7 @@
 
   async function fillFeaturedErc20ns () {
     if (!window.ethInitialized) return
+    if (!window.isValidEthNetwork) return
 
     const featured = await window.utils.getFeaturedErc20s()
 
@@ -186,6 +187,7 @@
   let erc20nAddress
   async function renderErc20nForm () {
     if (!(window.ethInitialized && window.nearInitialized)) return
+    if (!window.isValidEthNetwork) return
 
     if (window.urlParams.get('erc20n') === erc20nAddress) return
     else erc20nAddress = window.urlParams.get('erc20n')

--- a/src/html/network-banner.html
+++ b/src/html/network-banner.html
@@ -10,7 +10,7 @@
   async function renderBanner () {
     if (!window.ethInitialized) return
 
-    if (process.env.ethNetworkId === window.connectedEthNetwork) {
+    if (window.isValidEthNetwork) {
       // Correct eth network is selected, so enable scrolling
       document.body.style.overflow = null;
       window.dom.hide('unsupportedNetworkBanner')

--- a/src/html/transfers.html
+++ b/src/html/transfers.html
@@ -389,6 +389,7 @@ function renderTransfer (transfer, { inProgress }) {
 
 async function updateTransfers () {
   if (!(window.ethInitialized && window.nearInitialized)) return
+  if (!window.isValidEthNetwork) return
 
   const transfers = await window.transfers.get()
 

--- a/src/js/authEthereum.js
+++ b/src/js/authEthereum.js
@@ -7,7 +7,7 @@ import {
 } from '@near-eth/client'
 import render from './render'
 import { onClick } from './domHelpers'
-import { chainIdToEthNetwork, ethNetworkToChainId } from './utils'
+import { chainIdToEthNetwork } from './utils'
 
 // SWAP IN YOUR OWN INFURA_ID FROM https://infura.io/dashboard/ethereum
 const INFURA_ID = '9c91979e95cb4ef8a61eb029b4217a1a'
@@ -54,11 +54,7 @@ async function login () {
 
   render()
 
-  if (window.nearInitialized) {
-    checkTransferStatuses(
-      { loop: window.LOOP_INTERVAL, expectedEthChainId: ethNetworkToChainId[process.env.ethNetworkId] }
-    )
-  }
+  if (window.nearInitialized) checkTransferStatuses({ loop: window.LOOP_INTERVAL })
 }
 
 onClick('authEthereum', login)

--- a/src/js/authEthereum.js
+++ b/src/js/authEthereum.js
@@ -7,7 +7,7 @@ import {
 } from '@near-eth/client'
 import render from './render'
 import { onClick } from './domHelpers'
-import { ethNetworks } from './utils'
+import { chainIdToEthNetwork, ethNetworkToChainId } from './utils'
 
 // SWAP IN YOUR OWN INFURA_ID FROM https://infura.io/dashboard/ethereum
 const INFURA_ID = '9c91979e95cb4ef8a61eb029b4217a1a'
@@ -42,17 +42,23 @@ async function login () {
     render()
   })
   provider.on('chainChanged', (chainId) => {
-    window.connectedEthNetwork = ethNetworks[chainId]
+    window.connectedEthNetwork = chainIdToEthNetwork[chainId]
+    window.isValidEthNetwork = window.connectedEthNetwork === process.env.ethNetworkId
     render()
   })
 
   window.ethUserAddress = provider.selectedAddress
-  window.connectedEthNetwork = ethNetworks[provider.chainId]
+  window.connectedEthNetwork = chainIdToEthNetwork[provider.chainId]
+  window.isValidEthNetwork = window.connectedEthNetwork === process.env.ethNetworkId
   window.ethInitialized = true
 
   render()
 
-  if (window.nearInitialized) checkTransferStatuses({ loop: window.LOOP_INTERVAL })
+  if (window.nearInitialized) {
+    checkTransferStatuses(
+      { loop: window.LOOP_INTERVAL, expectedEthChainId: ethNetworkToChainId[process.env.ethNetworkId] }
+    )
+  }
 }
 
 onClick('authEthereum', login)

--- a/src/js/authNear.js
+++ b/src/js/authNear.js
@@ -36,11 +36,7 @@ function login () {
 
   render()
 
-  if (window.ethInitialized) {
-    checkTransferStatuses(
-      { loop: window.LOOP_INTERVAL, expectedEthChainId: ethNetworkToChainId[process.env.ethNetworkId] }
-    )
-  }
+  if (window.ethInitialized) checkTransferStatuses({ loop: window.LOOP_INTERVAL })
 }
 
 // The NEAR signin flow redirects from the current URL to NEAR Wallet,

--- a/src/js/authNear.js
+++ b/src/js/authNear.js
@@ -36,7 +36,11 @@ function login () {
 
   render()
 
-  if (window.ethInitialized) checkTransferStatuses({ loop: window.LOOP_INTERVAL })
+  if (window.ethInitialized) {
+    checkTransferStatuses(
+      { loop: window.LOOP_INTERVAL, expectedEthChainId: ethNetworkToChainId[process.env.ethNetworkId] }
+    )
+  }
 }
 
 // The NEAR signin flow redirects from the current URL to NEAR Wallet,

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -32,8 +32,3 @@ export const chainIdToEthNetwork = {
   '0x3': 'ropsten',
   '0x4': 'rinkeby'
 }
-export const ethNetworkToChainId = {
-  'main': '0x1',
-  'ropsten': '0x3',
-  'rinkeby': '0x4'
-}

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -27,8 +27,13 @@ export async function getFeaturedErc20s () {
   )
 }
 
-export const ethNetworks = {
+export const chainIdToEthNetwork = {
   '0x1': 'main',
   '0x3': 'ropsten',
   '0x4': 'rinkeby'
+}
+export const ethNetworkToChainId = {
+  'main': '0x1',
+  'ropsten': '0x3',
+  'rinkeby': '0x4'
 }


### PR DESCRIPTION
Trying to query metadata on the wrong eth chain will throw console errors so don't render if the selected Ethereum chain id in the wallet doesn't match the chain id of the bridge.

Also leverages the checkStatus fix in this PR https://github.com/near/rainbow-bridge-client/pull/4