### PR TITLE
fix: UI improvements, add faucet link

### DIFF
--- a/src/css/global.css
+++ b/src/css/global.css
@@ -185,8 +185,8 @@ li {
 }
 
 ::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
-  color: #ddd;
-  opacity: 1; /* Firefox */
+  color: #aaa;
+  opacity: 0.5; /* Firefox */
 }
 
 @media (prefers-color-scheme: dark) {

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -184,6 +184,11 @@ li {
   padding-bottom: 1em;
 }
 
+::placeholder { /* Chrome, Firefox, Opera, Safari 10.1+ */
+  color: #ddd;
+  opacity: 1; /* Firefox */
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     --gray: #aaa;
@@ -212,10 +217,6 @@ li {
   margin: 0 auto;
   text-align: center;
   padding: 1em;
-}
-
-.concept-near {
-  color: var(--red);
 }
 
 .concept-ethereum {

--- a/src/html/erc20-form.html
+++ b/src/html/erc20-form.html
@@ -50,7 +50,7 @@
     </div>
     <footer>
       <button disabled data-behavior="erc20Submit" class="cta">
-        Submit transfer
+        Approve transfer
       </button>
       <button type="button" class="cancel" data-behavior="goHome">
         Cancel
@@ -78,11 +78,10 @@
         <div data-behavior="erc20AddressError" class="errorMessage"></div>
       </form>
       <div class="separator">
-        <strong>or</strong>
+        <strong>or choose</strong>
       </div>
       <form method="get">
         <header>
-          <h3>Select a token</h3>
           <div class="space-between" style="font-size:.75em;margin-bottom:.5em">
             <span>Token name</span>
             <span>Available balance</span>
@@ -225,7 +224,10 @@
       input.classList.add('error')
       input.value = erc20Address
       window.dom.find('erc20FreeForm').classList.add('error')
-      window.dom.fill('erc20AddressError').with(e.message)
+      console.error(e)
+      window.dom.fill('erc20AddressError').with(
+        'Sorry, the provided Ethereum address doesn\'t look like a valid ERC20 token contract'
+      )
       window.dom.show('erc20AddressError')
       window.dom.show('sendNaturalErc20')
       return

--- a/src/html/erc20n-form.html
+++ b/src/html/erc20n-form.html
@@ -78,11 +78,10 @@
         <div data-behavior="erc20nAddressError" class="errorMessage"></div>
       </form>
       <div class="separator">
-        <strong>or</strong>
+        <strong>or choose</strong>
       </div>
       <form method="get">
         <header>
-          <h3>Select a token</h3>
           <div class="space-between" style="font-size:.75em;margin-bottom:.5em">
             <span>Token name</span>
             <span>Available balance</span>
@@ -225,7 +224,10 @@
       input.classList.add('error')
       input.value = erc20Address
       window.dom.find('erc20nFreeForm').classList.add('error')
-      window.dom.fill('erc20nAddressError').with(e.message)
+      console.error(e)
+      window.dom.fill('erc20nAddressError').with(
+        'Sorry, the provided Ethereum address doesn\'t look like a valid ERC20 token contract'
+      )
       window.dom.show('erc20nAddressError')
       window.dom.show('sendBridgedNep141')
       return

--- a/src/html/landing.html
+++ b/src/html/landing.html
@@ -14,22 +14,14 @@
   </h1>
   <div style="margin: 0 auto 2.5em; max-width: 22em; text-align: center; padding: 1em">
     <p>
-      From
-      <a
-        href="https://eips.ethereum.org/EIPS/eip-20"
-        rel="nofollow"
-        class="concept-ethereum"
-      >ERC20</a>
-      to
-      <a
-        href="https://github.com/nearprotocol/NEPs/pull/141"
-        rel="nofollow"
-        class="concept-near"
-      >NEP141</a>
-      and back! Connect your NEAR and Ethereum accounts to get started.
+      Transfer tokens between Ethereum and NEAR! Connect your NEAR and Ethereum accounts to get started.
     </p>
     <form method="get" class="panel">
       <include src="authenticated-accounts.html"></include>
+      <p style="margin-top: 1.5em; font-size: small;">
+        Don’t have a NEAR account? Create one
+        <a href="https://wallet.near.org/">here</a>.
+      </p>
       <button data-behavior="landingSubmit" class="cta" style="margin-top: 2em">
         Begin new transfer
       </button>

--- a/src/html/transfers.html
+++ b/src/html/transfers.html
@@ -370,7 +370,7 @@ function renderTransfer (transfer, { inProgress }) {
           ${transfer.recipient}
         </span>
       </div>
-      <footer class="${openTransferDetails[transfer.id] ? 'open' : ''}">
+      <footer class="${openTransferDetails[transfer.id] || transfer.status !== 'completed' ? 'open' : ''}">
         <ol class="transfer-details">${transfer.steps.map(step => (
           `<li class="${step.status}">
             <span>${step.description}</span>


### PR DESCRIPTION
https://hackmd.io/wKy5TKXxQqGvQVIiOdVdUg
- [x] Expand transfer process by default if not completed
- [ ] "Begin new transfer" button styling to text link ? (pending)
- [x] Remove erc20 and nep141 terminology
![image](https://user-images.githubusercontent.com/29397451/110738903-6dce0400-8273-11eb-83e6-832bd9f364b6.png)

- [x] Add create near account faucet link
![image](https://user-images.githubusercontent.com/29397451/110738919-79212f80-8273-11eb-8d3c-78e65a30364f.png)

- [ ] Consider replacing “New Transfer” with “{icon} → {icon}” (i.e. Ethereum and NEAR icons) to better reinforce the direction of transfer.
- [x] Improve invalid token error message
![image](https://user-images.githubusercontent.com/29397451/110739448-8a1e7080-8274-11eb-8618-ad2d2702ba46.png)

- [x] Placeholder lighter grey, remove "select a token"
![image](https://user-images.githubusercontent.com/29397451/110739414-78d56400-8274-11eb-8a30-1436583b0b00.png)

- [ ] Improve transfer submission amount: https://github.com/near/rainbow-bridge-frontend/issues/121
- [x] Rename "Submit transfer" -> "Approve transfer" 
![image](https://user-images.githubusercontent.com/29397451/110739471-9acee680-8274-11eb-8355-c03882286877.png)

- [ ]  Skip approve step if allowance is enough: https://github.com/near/rainbow-bridge-frontend/issues/139