### PR TITLE
feat: add transfer recovery from lock/withdraw hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "semantic-release": "^17.1.2"
   },
   "dependencies": {
-    "@near-eth/client": "^1.0.0",
-    "@near-eth/nep141-erc20": "^1.0.0",
+    "@near-eth/client": "^1.1.0",
+    "@near-eth/nep141-erc20": "^1.1.0",
     "@walletconnect/web3-provider": "^1.2.1",
     "decimal.js": "^10.2.1",
     "near-api-js": "~0.36.3",

--- a/src/html/restore-transfer.html
+++ b/src/html/restore-transfer.html
@@ -1,0 +1,189 @@
+<div class="restore" data-behavior="restore" style="display:none">
+  <div data-behavior="locateTransfer">
+    <header>
+      <h2>Restore transfer</h2>
+      <p>Restore a bridge transfer by providing it's deposit transaction hash from Near or Ethereum.</p>
+    </header>
+    <form method="get" class="restore-form" data-behavior="restoreForm">
+      <label for="txHashInput">Transaction hash</label>
+      <input
+        id="txHashInput"
+        data-behavior="txHashInput"
+        placeholder="0x89d24A6b4C.../4vcWEVTeg5C"
+        autoComplete="off"
+      />
+      <div data-behavior="txHashError" class="errorMessage"></div>
+      <footer>
+        <button class="cta" data-behavior="restoreSubmit" disabled>
+          Locate transfer
+        </button>
+        <button type="button" class="cancel" data-behavior="cancelRestore">
+          Cancel
+        </button>
+      </footer>
+    </form>
+  </div>
+  <div data-behavior="transferFound" style="display:none">
+    <header>
+      <h2>Transfer found!</h2>
+      <p>The following bridge transfer was found and is ready to be restored.</p>
+    </header>
+    <div data-behavior="restoredTransferContainer">
+
+    </div>
+    <footer>
+      <button class="cta" data-behavior="confirmRestore">
+        Restore transfer
+      </button>
+      <button type="button" class="cancel" data-behavior="cancelRestore">
+        Cancel
+      </button>
+    </footer>
+  </div>
+</div>
+<style>
+  .restore {
+    max-width: 25em;
+    margin: 0 auto;
+    padding: 1em;
+  }
+  .restore header {
+    text-align: center;
+    margin-top: 5em;
+    margin-bottom: 5em;
+  }
+  .restore input {
+    margin-top: 0.5em;
+  }
+  .restore footer {
+    margin-top: 2em;
+  }
+  .restore button {
+    margin-top: 1em;
+  }
+  .restore .errorMessage {
+    margin-top: 1em;
+  }
+  .restoredTransfer {
+    overflow: hidden;
+    margin: 1rem auto;
+    font-size: 0.75em;
+    border-radius: 10px;
+
+  }
+  .restoredTransfer header {
+    background-color: #FFDBB2;
+    text-align: left;
+    padding: 0.6rem 1rem;
+    display: grid;
+    grid-template-columns: auto auto;
+    justify-content: space-between;
+    align-items: center;
+    grid-gap: 1em;
+    margin-bottom: 0;
+    margin-top: 0;
+  }
+  .restoredTransfer header h3 {
+    color: #452500;
+  }
+  .restoredTransfer div {
+    background-color: #FFF6ED;
+    color: #995200;
+    padding: 0.7rem 1rem;
+    display: grid;
+    grid-gap: 7rem;
+    grid-template-columns: auto auto;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .restoredTransfer > div > *:first-child {
+    color: #E78513;
+  }
+
+</style>
+<script>
+window.addEventListener('load', function handleInputTxHashEvents () {
+  let transferToRestore
+  const txHashInput = window.dom.find('txHashInput')
+  const restoreSubmit = window.dom.find('restoreSubmit')
+  txHashInput.onkeyup = function enableOrDisable (e) {
+    if (e.target.value.length > 0) restoreSubmit.disabled = false
+    else restoreSubmit.disabled = true
+  }
+  window.dom.find('restoreForm').onsubmit = async function restorefromHash (e) {
+    e.preventDefault()
+    try {
+      if (/^(0x)?[0-9a-f]{64}$/i.test(txHashInput.value)) {
+        transferToRestore = await window.nep141Xerc20.naturalErc20.recover(txHashInput.value)
+      } else {
+        transferToRestore = await window.nep141Xerc20.bridgedNep141.recover(txHashInput.value)
+      }
+      console.log(transferToRestore)
+      txHashInput.value = ''
+      window.dom.fill('txHashError').with('')
+      window.dom.find('erc20FreeForm').classList.remove('error')
+      window.dom.hide('locateTransfer')
+      window.dom.show('transferFound')
+      window.dom.fill('restoredTransferContainer').with(
+        renderRestoredTransfer(transferToRestore, { inProgress: true })
+      )
+    } catch (e) {
+      console.error(e)
+      txHashInput.classList.add('error')
+      window.dom.fill('txHashError').with(
+        'Failed to locate transfer. Please double check your transaction hash'
+      )
+    }
+  }
+  window.dom.find('confirmRestore').onclick = async function trackRestoredTransfer () {
+    window.transfers.track(transferToRestore)
+    window.urlParams.clear()
+    window.render()
+    window.dom.show('locateTransfer')
+    window.dom.hide('transferFound')
+  }
+  window.dom.findAll('cancelRestore').map(cancelBtn => cancelBtn.onclick = async function forgetFoundTransfer () {
+    const txHashInput = window.dom.find('txHashInput')
+    txHashInput.value = ''
+    txHashInput.classList.remove('error')
+    window.dom.fill('txHashError').with('')
+    restoreSubmit.disabled = true
+    urlParams.clear()
+    window.render()
+    window.dom.show('locateTransfer')
+    window.dom.hide('transferFound')
+  })
+})
+function renderRestoredTransfer (transfer, { inProgress }) {
+  transfer = window.transfers.decorate(transfer, { locale: 'en_US' })
+  return `
+    <div class="restoredTransfer">
+      <header>
+        <h3>${window.utils.formatLargeNum(transfer.amount, transfer.decimals)} ${transfer.sourceTokenName}</h3>
+      </header>
+      <div>
+        <span>From</span>
+        <span class="account-with-icon ${transfer.sourceNetwork}" title="${transfer.sender}">
+          ${transfer.sender}
+        </span>
+      </div>
+      <div>
+        <span>To</span>
+        <span class="account-with-icon ${transfer.destinationNetwork}" title="${transfer.recipient}">
+          ${transfer.recipient}
+        </span>
+      </div>
+    </div>
+  `
+}
+function renderRestoreForm () {
+  if (!(window.ethInitialized && window.nearInitialized)) return
+
+  if (window.urlParams.get('new') === 'restore') {
+    window.dom.show('restore')
+  } else {
+    window.dom.hide('restore')
+  }
+}
+window.renderers.push(renderRestoreForm)
+ </script>

--- a/src/html/transfers.html
+++ b/src/html/transfers.html
@@ -5,40 +5,15 @@
     <button data-behavior="newTransfer" class="cta" style="margin-top: 2em">
       Begin new transfer
     </button>
+    <p class="or">or</p>
+    <button data-behavior="newRecovery" class="cta">
+      Restore transfer
+    </button>
     <!-- TODO: <nav> -->
   </header>
-  <div class="recovery-container">
-    <button class="link" data-behavior="toggleRecovery">Recover with deposit tx hash</button>
-    <form data-behavior="txHashRecoveryForm" style="display:none">
-      <div class="recover">
-        <input
-          data-behavior="txHashInput"
-          placeholder="0x89d24A6b4C..."
-          autoComplete="off"
-        />
-        <button>Recover</button>
-      </div>
-      <div data-behavior="txHashError" class="errorMessage"></div>
-    </form>
-  </div>
   <div data-behavior="transfers-container" style="margin-top: 3rem"></div>
 </div>
 <style>
-  .recovery-container {
-    margin-top: 2em;
-    text-align: center;
-  }
-  .recover {
-    display: flex;
-    flex-direction: row;
-    margin-top: 1em;
-  }
-  .recover > input {
-    margin-right: 1em;
-  }
-  .errorMessage {
-    margin-top: 1em;
-  }
   .transfers {
     margin-top: 4em;
     width: 100%;
@@ -52,6 +27,13 @@
   }
   .transfers nav button {
     border-radius: 100em;
+  }
+  .transfers > header :last-child {
+    background-color: var(--light-gray);
+    color: var(--fg-bold)
+  }
+  .or {
+    margin: 1em;
   }
   .transfer.in-progress {
     --bg-dark: #FFDBB2;
@@ -338,6 +320,10 @@ window.addEventListener('load', function addLandingHandlers () {
     window.urlParams.set({ new: 'transfer' })
     window.render()
   })
+  window.dom.onClick('newRecovery', function startTransferRecovery () {
+    window.urlParams.set({ new: 'restore' })
+    window.render()
+  })
   // transfers are rendered after page load, so we add one click handler to the
   // body tag to handle clicking each kind of button on a transfer
   document.querySelector('body').addEventListener('click', event => {
@@ -360,35 +346,6 @@ window.addEventListener('load', function addLandingHandlers () {
     openTransferDetails[transferId] = !openTransferDetails[transferId]
     footer.classList.toggle('open')
     adjustTransferDetailsHeights()
-  })
-
-  const txHashInput = window.dom.find('txHashInput')
-  const txHashRecoveryForm = window.dom.find('txHashRecoveryForm')
-
-  txHashRecoveryForm.onsubmit = async function recoverTransfer(e) {
-    e.preventDefault()
-    console.log(txHashInput.value)
-    try {
-      if (/^(0x)?[0-9a-f]{64}$/i.test(txHashInput.value)) {
-        await window.nep141Xerc20.naturalErc20.recover(txHashInput.value)
-      } else {
-        await window.nep141Xerc20.bridgedNep141.recover(txHashInput.value)
-      }
-      window.dom.fill('txHashError').with('')
-    } catch (e) {
-      console.error(e)
-      window.dom.fill('txHashError').with(e.message)
-    }
-  }
-
-  window.dom.onClick('toggleRecovery', function toggleRecoveryDisplay () {
-    if (txHashRecoveryForm.style.display === 'none') {
-      txHashRecoveryForm.style.display = ''
-      window.dom.fill('txHashError').with('')
-      txHashInput.value = ''
-    } else {
-      txHashRecoveryForm.style.display = 'none'
-    }
   })
 })
 // tracks UI state for which transfers have "view details" open

--- a/src/html/transfers.html
+++ b/src/html/transfers.html
@@ -7,9 +7,38 @@
     </button>
     <!-- TODO: <nav> -->
   </header>
+  <div class="recovery-container">
+    <button class="link" data-behavior="toggleRecovery">Recover with deposit tx hash</button>
+    <form data-behavior="txHashRecoveryForm" style="display:none">
+      <div class="recover">
+        <input
+          data-behavior="txHashInput"
+          placeholder="0x89d24A6b4C..."
+          autoComplete="off"
+        />
+        <button>Recover</button>
+      </div>
+      <div data-behavior="txHashError" class="errorMessage"></div>
+    </form>
+  </div>
   <div data-behavior="transfers-container" style="margin-top: 3rem"></div>
 </div>
 <style>
+  .recovery-container {
+    margin-top: 2em;
+    text-align: center;
+  }
+  .recover {
+    display: flex;
+    flex-direction: row;
+    margin-top: 1em;
+  }
+  .recover > input {
+    margin-right: 1em;
+  }
+  .errorMessage {
+    margin-top: 1em;
+  }
   .transfers {
     margin-top: 4em;
     width: 100%;
@@ -331,6 +360,32 @@ window.addEventListener('load', function addLandingHandlers () {
     openTransferDetails[transferId] = !openTransferDetails[transferId]
     footer.classList.toggle('open')
     adjustTransferDetailsHeights()
+  })
+
+  const txHashInput = window.dom.find('txHashInput')
+  const txHashRecoveryForm = window.dom.find('txHashRecoveryForm')
+
+  txHashRecoveryForm.onsubmit = async function recoverTransfer(e) {
+    e.preventDefault()
+    // TODO: add support for Near withdraw tx recovery
+    console.log(txHashInput.value)
+    try {
+      await window.nep141Xerc20.naturalErc20.recover(txHashInput.value)
+      window.dom.fill('txHashError').with('')
+    } catch (e) {
+      console.error(e)
+      window.dom.fill('txHashError').with(e.message)
+    }
+  }
+
+  window.dom.onClick('toggleRecovery', function toggleRecoveryDisplay () {
+    if (txHashRecoveryForm.style.display === 'none') {
+      txHashRecoveryForm.style.display = ''
+      window.dom.fill('txHashError').with('')
+      txHashInput.value = ''
+    } else {
+      txHashRecoveryForm.style.display = 'none'
+    }
   })
 })
 // tracks UI state for which transfers have "view details" open

--- a/src/html/transfers.html
+++ b/src/html/transfers.html
@@ -367,10 +367,13 @@ window.addEventListener('load', function addLandingHandlers () {
 
   txHashRecoveryForm.onsubmit = async function recoverTransfer(e) {
     e.preventDefault()
-    // TODO: add support for Near withdraw tx recovery
     console.log(txHashInput.value)
     try {
-      await window.nep141Xerc20.naturalErc20.recover(txHashInput.value)
+      if (/^(0x)?[0-9a-f]{64}$/i.test(txHashInput.value)) {
+        await window.nep141Xerc20.naturalErc20.recover(txHashInput.value)
+      } else {
+        await window.nep141Xerc20.bridgedNep141.recover(txHashInput.value)
+      }
       window.dom.fill('txHashError').with('')
     } catch (e) {
       console.error(e)

--- a/src/index.html
+++ b/src/index.html
@@ -54,6 +54,7 @@
     <include src="erc20-form.html"></include>
     <include src="erc20n-form.html"></include>
     <include src="bridge-erc20-form.html"></include>
+    <include src="restore-transfer.html"></include>
   </div>
 
   <script src="./js/index.js"></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1272,21 +1272,21 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@near-eth/client@1.0.0", "@near-eth/client@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@near-eth/client/-/client-1.0.0.tgz#750284d6f8b072f3f0fb2f9321bfdc9d32a6a64e"
-  integrity sha512-n1RUNXDuojaebzC3IJj5yyv0dtVUvGTf3stU1a9ovty7VeOsRGfYvMdorUfyIfEdguuvOJbmqcyR3g4BJyjrUg==
+"@near-eth/client@1.1.0", "@near-eth/client@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@near-eth/client/-/client-1.1.0.tgz#9b34384aeda7dc8fefe1ee3707a0917402bc2f75"
+  integrity sha512-WUZDc/U8afcXxhkgHtdFzAZoTKZwKe2vUCtirQ9Yq0EwVrvLM+hxyo6mXwmnyPtjIV5jamkrwqI/746Ae8n1JQ==
   dependencies:
     bn.js "^5.1.3"
     decimal.js "^10.2.1"
     near-api-js near/near-api-js#account-type-fixes
 
-"@near-eth/nep141-erc20@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@near-eth/nep141-erc20/-/nep141-erc20-1.0.0.tgz#fc84d6cd07d25ad7e8a25aa3e8a548315a8904a8"
-  integrity sha512-i+qMO1eTHdfxZSnaQS05rkp7poAl9j2HpvFDvcln9dri3XKZwrIegNmf+r5/L9mrQsL2WgJg9h45gZ0O1itXWQ==
+"@near-eth/nep141-erc20@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@near-eth/nep141-erc20/-/nep141-erc20-1.1.0.tgz#ac6832c37d142c88579050db57586c0ed396776a"
+  integrity sha512-EGl5m4tTXsD2lwlPuEOyF9xEGMdZXVAojaLuy5Ic8bMoO7OhnLrGoehwpOIr0HJVhifUvZsxVsaxkgnFhhyGSA==
   dependencies:
-    "@near-eth/client" "1.0.0"
+    "@near-eth/client" "1.1.0"
     bn.js "^5.1.3"
     bs58 "^4.0.1"
     eth-object near/eth-object#54e03b8aac8208cf724e206d49ffb8bdd30451d7


### PR DESCRIPTION
Implementation for https://github.com/near/rainbow-bridge-frontend/issues/136
Requires client release with https://github.com/near/rainbow-bridge-client/pull/10
Given an eth lock hash or a near withdraw hash, recreate a transfer object which can be finalized (mint/unlock)