### PR TITLE
Increase minting deposit back to 0.06N

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@near-eth/client": "^1.1.1",
-    "@near-eth/nep141-erc20": "^1.2.1",
+    "@near-eth/nep141-erc20": "^1.2.2",
     "@walletconnect/web3-provider": "^1.2.1",
     "decimal.js": "^10.2.1",
     "near-api-js": "^0.39.0",

--- a/src/js/authNear.js
+++ b/src/js/authNear.js
@@ -26,7 +26,7 @@ window.nearUserAddress = window.nearConnection.getAccountId()
 
 onClick('authNear', () => {
   // sign in without access keys
-  window.nearConnection.requestSignIn()
+  window.nearConnection.requestSignIn({ contractId: process.env.nearTokenFactoryAccount })
 })
 
 function login () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1281,10 +1281,10 @@
     decimal.js "^10.2.1"
     near-api-js "^0.39.0"
 
-"@near-eth/nep141-erc20@^1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@near-eth/nep141-erc20/-/nep141-erc20-1.2.1.tgz#6878735594e4b8cab77a6509cbbe547fe6f479fb"
-  integrity sha512-9gldrnClW0l97LEz/Snrua1JU80eX1FW4UGqFESHfpkx3NW/IrBRu9Sz8Qtotxvfckyy5MsfvsU7A32xHsF+Zg==
+"@near-eth/nep141-erc20@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@near-eth/nep141-erc20/-/nep141-erc20-1.2.2.tgz#9ffcb09aad26344aa884322d851b4c2aca961908"
+  integrity sha512-YRH1+h6YUZ0StndgiY0+1vAedTD7Gx0Hm7ezEQoNO06CB06LpZPgQ6FfoRhGa/byvSxYOm5uOXIvxrp3u1PnuQ==
   dependencies:
     "@near-eth/client" "1.1.1"
     bn.js "^5.1.3"


### PR DESCRIPTION
This incorporates the change at https://github.com/near/rainbow-bridge-client/commit/9eaed466969c617e9477f2d003fc4f3f9096a474

We need to attach more than 0.006. We might only need to attach 0.02. But for now it's fastest to bump it back to 0.06. And now that faucet.paras.id gives out 0.1N, this is safe.