### PR TITLE
UI fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "semantic-release": "^17.1.2"
   },
   "dependencies": {
-    "@near-eth/client": "^1.1.1",
-    "@near-eth/nep141-erc20": "^1.2.4",
+    "@near-eth/client": "^1.2.0",
+    "@near-eth/nep141-erc20": "^1.3.1",
     "decimal.js": "^10.2.1",
     "near-api-js": "^0.39.0",
     "@walletconnect/web3-provider": "^1.4.1",

--- a/src/css/global.css
+++ b/src/css/global.css
@@ -246,7 +246,8 @@ button[disabled] {
   cursor: not-allowed;
   transform: none;
 }
-[disabled] .cancel, .cancel[disabled] {
+[disabled] .cancel,
+.cancel[disabled] {
   color: gray;
   cursor: not-allowed;
   background: none;
@@ -324,6 +325,15 @@ li {
   margin: 0 auto;
   text-align: center;
   padding: 1em;
+}
+
+.beta-tag {
+  color: var(--blue-500);
+  border: 1px solid var(--blue-500);
+  border-radius: 4px;
+  padding: 2px 4px;
+  font-size: var(--fs-micro);
+  font-weight: var(--fw-regular);
 }
 
 .concept-ethereum {

--- a/src/css/title.css
+++ b/src/css/title.css
@@ -1,18 +1,38 @@
-.title {
+.logo--landing-page {
   text-align: center;
+  margin: 64px auto 0;
+  width: 200px;
 }
 
-.title > * {
-  display: block;
+.logo--landing-page .rainbow-icon {
+  width: 72px;
+  margin: 0 auto var(--spacing-m);
 }
 
-.title > svg {
+.logo--landing-page svg {
   margin: calc(0.5 * var(--spacing-m)) auto;
 }
 
-.title > small {
+.logo--landing-page small {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   color: var(--gray-600);
-  font-size: 0.5em;
-  margin-bottom: 0.5em;
-  font-weight: 400;
+  font-size: var(--base-font-size);
+  margin-bottom: var(--spacing-xs);
+  font-weight: var(--fw-regular);
+}
+
+.logo--landing-page small img {
+  margin: 0 var(--spacing-xs);
+}
+
+.logo--landing-page .logo-text--primary {
+  position: relative;
+}
+
+.logo-text--primary .beta-tag {
+  position: absolute;
+  top: 0;
+  right: -12px;
 }

--- a/src/html/alert-banner.html
+++ b/src/html/alert-banner.html
@@ -29,9 +29,9 @@
     />
   </svg>
   <span>
-    <strong>WARNING: </strong>Please note that this is a Beta version which is undergoing rapid testing and refinement. <br>
-    <strong>CAUTION: </strong>The Rainbow Bridge is currently incompatible with NEAR wallets that are secured with either Ledger devices,
-    or two-factor authentication. This issue will be resolved soon.
+    <strong>CAUTION: </strong>The Rainbow Bridge is temporarily incompatible
+    with NEAR wallets secured by Ledger devices and/or two-factor
+    authentication.
   </span>
 </aside>
 

--- a/src/html/alert-banner.html
+++ b/src/html/alert-banner.html
@@ -1,7 +1,7 @@
 <aside class="banner caution">
   <svg
-    width="16"
-    height="16"
+    width="25"
+    height="25"
     viewBox="0 0 16 16"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
@@ -29,6 +29,7 @@
     />
   </svg>
   <span>
+    <strong>WARNING: </strong>Please note that this is a Beta version which is undergoing rapide testing and refinement. <br>
     <strong>CAUTION: </strong>The Rainbow Bridge is currently incompatible with NEAR wallets that are secured with either Ledger devices,
     or two-factor authentication. This issue will be resolved soon.
   </span>
@@ -42,7 +43,6 @@
     font-size: var(--fs-micro);
     font-weight: var(--fw-regular);
     padding: var(--spacing-m);
-    text-align: center;
   }
 
   .banner svg {

--- a/src/html/alert-banner.html
+++ b/src/html/alert-banner.html
@@ -29,7 +29,7 @@
     />
   </svg>
   <span>
-    <strong>WARNING: </strong>Please note that this is a Beta version which is undergoing rapide testing and refinement. <br>
+    <strong>WARNING: </strong>Please note that this is a Beta version which is undergoing rapid testing and refinement. <br>
     <strong>CAUTION: </strong>The Rainbow Bridge is currently incompatible with NEAR wallets that are secured with either Ledger devices,
     or two-factor authentication. This issue will be resolved soon.
   </span>

--- a/src/html/bridge-erc20-form.html
+++ b/src/html/bridge-erc20-form.html
@@ -1,6 +1,6 @@
 <form data-behavior="bridgeErc20Form" class="container" style="display:none">
   <h1 style="background: url(img/unbridged.svg) top center no-repeat; font-size: 1.5em; padding: 12rem 0 2.5rem">
-    Setup <strong data-behavior="erc20Name"></strong> on NEAR
+    Set up <strong data-behavior="erc20Name"></strong> on NEAR
   </h1>
   <p>
     The <strong data-behavior="erc20Name"></strong>
@@ -12,7 +12,7 @@
   </p>
   <p>
     This is the first time the <strong data-behavior="erc20Name"></strong> token is being transferred to NEAR.
-    This requires a small, one-time setup fee of about 3$NEAR.
+    This requires a small, one-time setup fee of about 3 $NEAR.
   </p>
   <button style="margin-top: 3em">
     Bridge it!

--- a/src/html/bridge-erc20-form.html
+++ b/src/html/bridge-erc20-form.html
@@ -1,20 +1,18 @@
 <form data-behavior="bridgeErc20Form" class="container" style="display:none">
   <h1 style="background: url(img/unbridged.svg) top center no-repeat; font-size: 1.5em; padding: 12rem 0 2.5rem">
-    Token not yet bridged
+    Setup <strong data-behavior="erc20Name"></strong> on NEAR
   </h1>
   <p>
     The <strong data-behavior="erc20Name"></strong>
     <a
       href="https://eips.ethereum.org/EIPS/eip-20"
-      rel="nofollow"
+      target="_blank" rel="noopener noreferrer"
     >ERC20</a>
     token has not yet been bridged.
   </p>
   <p>
-    The
-    <a href="https://github.com/near/rainbow-token-connector" target="_blank">Fungible Token Connector</a>
-    allows sending any ERC20 token to NEAR, but requires an initial one-time deploy of a "BridgeToken"
-    <a href="https://docs.near.org/docs/roles/developer/contracts/intro#get-started" target="_blank">smart contract</a>.
+    This is the first time the <strong data-behavior="erc20Name"></strong> token is being transferred to NEAR.
+    This requires a small, one-time setup fee of about 3$NEAR.
   </p>
   <button style="margin-top: 3em">
     Bridge it!
@@ -22,10 +20,6 @@
   <button type="button" class="cancel" data-behavior="bridgeErc20Cancel">
     Cancel
   </button>
-  <p style="font-size: 0.75em; margin-top: 2em">
-    Deploying a new "Bridge Token" smart contract requires ~3 NEAR to cover
-    <a href="https://docs.near.org/docs/concepts/storage" target="_blank">storage fees</a>.
-  </p>
 </form>
 
 <script>

--- a/src/html/erc20-form.html
+++ b/src/html/erc20-form.html
@@ -166,7 +166,12 @@
       window.dom.hide('signInstruction')
     }
 
-    select.onclick = () => window.dom.show("erc20Modal");
+    select.onclick = () => {
+      window.urlParams.set({ erc20: '' })
+      window.dom.find("erc20FreeForm").value = ''
+      erc20Address = ''
+      window.dom.show("erc20Modal")
+    }
 
     amount.onkeyup = function enableOrDisable(e) {
       const balance = Number(window.dom.find("erc20Balance").innerHTML);

--- a/src/html/erc20-form.html
+++ b/src/html/erc20-form.html
@@ -169,7 +169,10 @@
     select.onclick = () => {
       window.urlParams.set({ erc20: '' })
       window.dom.find("erc20FreeForm").value = ''
+      window.dom.find("erc20FreeForm").classList.remove("error");
       erc20Address = ''
+      window.dom.fill("erc20AddressError").with("");
+      window.dom.hide("erc20AddressError");
       window.dom.show("erc20Modal")
     }
 

--- a/src/html/erc20n-form.html
+++ b/src/html/erc20n-form.html
@@ -160,7 +160,12 @@
       window.dom.hide('signInstruction')
     }
 
-    select.onclick = () => window.dom.show("erc20nModal");
+    select.onclick = () => {
+      window.dom.show('erc20nModal')
+      window.urlParams.set({ erc20n: '' })
+      window.dom.find('erc20nFreeForm').value = ''
+      erc20nAddress = ''
+    }
 
     amount.onkeyup = function enableOrDisableErc20n(e) {
       const balance = Number(window.dom.find("erc20nBalance").innerHTML);

--- a/src/html/erc20n-form.html
+++ b/src/html/erc20n-form.html
@@ -161,10 +161,13 @@
     }
 
     select.onclick = () => {
-      window.dom.show('erc20nModal')
       window.urlParams.set({ erc20n: '' })
       window.dom.find('erc20nFreeForm').value = ''
+      window.dom.find("erc20nFreeForm").classList.remove("error");
       erc20nAddress = ''
+      window.dom.fill("erc20nAddressError").with("");
+      window.dom.hide("erc20nAddressError");
+      window.dom.show('erc20nModal')
     }
 
     amount.onkeyup = function enableOrDisableErc20n(e) {

--- a/src/html/landing.html
+++ b/src/html/landing.html
@@ -24,15 +24,18 @@
     <form method="get" class="panel">
       <include src="authenticated-accounts.html"></include>
       <div class="cta-container">
-        <p class="create-account">
-          Need a NEAR account? Create one
-          <a href="https://faucet.paras.id/">here</a>.
-        </p>
         <button data-behavior="landingSubmit" class="full-width">
           Begin new transfer
         </button>
+        <button type="button" class="link button--missing-transfer" data-behavior="newRecovery">
+          Restore transfer
+        </button>
       </div>
     </form>
+    <p class="create-account">
+      Need a NEAR account? Create one
+      <a target="_blank" rel="noopener noreferrer" href="https://faucet.paras.id/">here</a>.
+    </p>
   </div>
 </div>
 <style>
@@ -55,7 +58,15 @@
       0px 3.39155px 8.04662px rgba(0, 0, 0, 0.0201946),
       0px 1.4113px 3.34838px rgba(0, 0, 0, 0.0140573);
     margin: 80px var(--spacing-m);
+    margin-bottom: 25px;
     padding: var(--spacing-m);
+  }
+  .create-account {
+    font-size: var(--fs-small);
+    border: 3px solid var(--gray-200);
+    border-radius: var(--br-base);
+    padding: var(--spacing-m);
+    margin: 0 var(--spacing-m);
   }
   @media (min-width: 928px) {
     .landing {
@@ -67,13 +78,19 @@
 
     .panel {
       margin: 80px auto;
+      margin-bottom: 25px;
+    }
+    .create-account {
+      margin: 0;
     }
   }
   .cta-container {
     margin-top: var(--spacing-xxl);
   }
-  .create-account {
-    font-size: var(--fs-micro);
+  .cta-container .button--missing-transfer {
+    font-size: var(--fs-body);
+    font-weight: var(--fw-regular);
+    margin-top: 0.5em;
   }
 </style>
 <script>

--- a/src/html/landing.html
+++ b/src/html/landing.html
@@ -78,7 +78,7 @@
 
     .panel {
       margin: 80px auto;
-      margin-bottom: 25px;
+      margin-bottom: var(--spacing-l);
     }
     .create-account {
       margin: 0;

--- a/src/html/landing.html
+++ b/src/html/landing.html
@@ -1,9 +1,6 @@
 <div class="landing" data-behavior="landing">
-  <h1 class="title">
-    <img
-      src="/img/rainbow-bridge.svg"
-      style="width: 2.3em; display: inline; margin-top: 2em"
-    />
+  <h1 class="logo--landing-page">
+    <img class="rainbow-icon" src="/img/rainbow-bridge.svg" />
     <small>
       ETH
       <img
@@ -13,8 +10,11 @@
       />
       NEAR
     </small>
-    <div>Rainbow</div>
-    <div>Bridge</div>
+    <div class="logo-text--primary">
+      Rainbow <br />
+      Bridge
+      <span class="beta-tag">Beta</span>
+    </div>
   </h1>
   <div class="content-wrapper">
     <p class="landing-blurb">
@@ -27,14 +27,23 @@
         <button data-behavior="landingSubmit" class="full-width">
           Begin new transfer
         </button>
-        <button type="button" class="link button--missing-transfer" data-behavior="newRecovery">
+        <button
+          type="button"
+          class="link button--missing-transfer"
+          data-behavior="newRecovery"
+        >
           Restore transfer
         </button>
       </div>
     </form>
     <p class="create-account">
       Need a NEAR account? Create one
-      <a target="_blank" rel="noopener noreferrer" href="https://faucet.paras.id/">here</a>.
+      <a
+        target="_blank"
+        rel="noopener noreferrer"
+        href="https://faucet.paras.id/"
+        >here</a
+      >.
     </p>
   </div>
 </div>

--- a/src/html/landing.html
+++ b/src/html/landing.html
@@ -58,7 +58,7 @@
       0px 3.39155px 8.04662px rgba(0, 0, 0, 0.0201946),
       0px 1.4113px 3.34838px rgba(0, 0, 0, 0.0140573);
     margin: 80px var(--spacing-m);
-    margin-bottom: 25px;
+    margin-bottom: var(--spacing-l);
     padding: var(--spacing-m);
   }
   .create-account {

--- a/src/html/landing.html
+++ b/src/html/landing.html
@@ -72,7 +72,7 @@
   }
   .create-account {
     font-size: var(--fs-small);
-    border: 3px solid var(--gray-200);
+    border: 1px solid var(--gray-300);
     border-radius: var(--br-base);
     padding: var(--spacing-m);
     margin: 0 var(--spacing-m);

--- a/src/html/nav.html
+++ b/src/html/nav.html
@@ -1,14 +1,15 @@
 <nav class="site-nav">
   <div class="site-nav__wrapper">
-    <a
-    class="navLogo"
-    data-behavior="navLogo"
-    href="/index.html"
-    title="Home"
-    ><span>Home</a>
+    <a class="navLogo" data-behavior="navLogo" href="/index.html" title="Home"
+      >Home<span class="beta-tag">Beta</span></a
+    >
 
     <div data-behavior="bridgesDropdown" class="bridges-nav">
-      <div id="bridge-dropdown" class="dropdown bridge-dropdown" aria-live="polite">
+      <div
+        id="bridge-dropdown"
+        class="dropdown bridge-dropdown"
+        aria-live="polite"
+      >
         <button aria-controls="bridge-dropdown" class="dropdown-trigger">
           <span class="bridge-indicator" style="background-color: #29b6af">
             <span class="visually-hidden">Connected</span>
@@ -25,31 +26,41 @@
             <span class="bridge-indicator" style="background-color: #29b6af">
               <span class="visually-hidden">Connected</span>
             </span>
-            <span> NEAR Mainnet <span class="arrow-divider">↔︎</span> Ethereum Mainnet</span>
+            <span>
+              NEAR Mainnet <span class="arrow-divider">↔︎</span> Ethereum
+              Mainnet</span
+            >
           </button>
           <div class="testnet-options">
             <button
-            aria-controls="bridge-dropdown"
-            class="dropdown-list__item"
-            onclick="location.href='https://ropsten.bridgetonear.org';"
-          >
-            <span class="bridge-indicator" style="background-color: #ff4a8d">
-              <span class="visually-hidden">Connected</span>
-            </span>
-            <span> NEAR Testnet <span class="arrow-divider">↔︎</span> Ethereum Ropsten </span>
-          </button>
+              aria-controls="bridge-dropdown"
+              class="dropdown-list__item"
+              onclick="location.href='https://ropsten.bridgetonear.org';"
+            >
+              <span class="bridge-indicator" style="background-color: #ff4a8d">
+                <span class="visually-hidden">Connected</span>
+              </span>
+              <span>
+                NEAR Testnet <span class="arrow-divider">↔︎</span> Ethereum
+                Ropsten
+              </span>
+            </button>
           </div>
         </div>
       </div>
     </div>
   </div>
   <div class="site-nav__wrapper">
-  <div
+    <div
       data-behavior="accountsDropdown"
       class="accounts-nav"
       style="display: none"
     >
-      <div id="accounts-dropdown" class="dropdown account-dropdown" aria-live="polite">
+      <div
+        id="accounts-dropdown"
+        class="dropdown account-dropdown"
+        aria-live="polite"
+      >
         <button aria-controls="accounts-dropdown" class="dropdown-trigger">
           <img
             data-behavior="ethConnected"
@@ -66,7 +77,10 @@
               class="account-with-icon reverse ethereum"
               data-behavior="ethUser"
             ></span>
-            <button class="button-size--small button-variant--secondary" data-behavior="disconnectEthereum">
+            <button
+              class="button-size--small button-variant--secondary"
+              data-behavior="disconnectEthereum"
+            >
               Disconnect
             </button>
           </div>
@@ -75,7 +89,10 @@
               class="account-with-icon reverse near"
               data-behavior="nearUser"
             ></span>
-            <button class="button-size--small button-variant--secondary" data-behavior="disconnectNear">
+            <button
+              class="button-size--small button-variant--secondary"
+              data-behavior="disconnectNear"
+            >
               Disconnect
             </button>
           </div>
@@ -111,6 +128,16 @@
     display: block;
     margin-right: var(--spacing-xxl);
     text-indent: -999px;
+    position: relative;
+    padding-right: 104px;
+  }
+
+  .navLogo .beta-tag {
+    position: absolute;
+    top: 50%;
+    right: 0;
+    text-indent: 0;
+    transform: translateY(-50%);
   }
 
   .dropdown {
@@ -197,7 +224,7 @@
     background-color: transparent;
   }
 
-  button.dropdown-list__item  {
+  button.dropdown-list__item {
     border: none;
     background-color: transparent;
     color: var(--gray-700);

--- a/src/html/transfers.html
+++ b/src/html/transfers.html
@@ -521,10 +521,7 @@
               `<button class="button--cta button-size--small" data-behavior="transferCallToAction">${transfer.callToAction}</button>`
           )}
           ${window.dom.toString(
-            (transfer.status === "completed" || // transfer completed
-             (transfer.type === '@near-eth/nep141-erc20/natural-erc20/sendToNear' && !transfer.completedStep) || // transfer from Ethereum not yet approved
-             (transfer.completedStep === 'approve-natural-erc20-to-nep141' && transfer.status === 'action-needed') || // approved but not transfered (not yet locked)
-             (transfer.completedStep === 'approve-natural-erc20-to-nep141' && transfer.status === 'failed')) && // approved but not transfered (lock failed)
+            transfer.status === "completed" &&
               `<button class="button--delete button-size--small" data-behavior="deleteTransfer"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M2 4H3.33333H14" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
                 <path d="M5.3335 4.00004V2.66671C5.3335 2.31309 5.47397 1.97395 5.72402 1.7239C5.97407 1.47385 6.31321 1.33337 6.66683 1.33337H9.3335C9.68712 1.33337 10.0263 1.47385 10.2763 1.7239C10.5264 1.97395 10.6668 2.31309 10.6668 2.66671V4.00004M12.6668 4.00004V13.3334C12.6668 13.687 12.5264 14.0261 12.2763 14.2762C12.0263 14.5262 11.6871 14.6667 11.3335 14.6667H4.66683C4.31321 14.6667 3.97407 14.5262 3.72402 14.2762C3.47397 14.0261 3.3335 13.687 3.3335 13.3334V4.00004H12.6668Z" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
@@ -618,9 +615,10 @@
 
       const transfers = await window.transfers.get();
       const currentParams = Object.keys(window.urlParams.get());
-      const allParams = ['new', 'erc20', 'erc20n']
+      const appUrlPaths = ['new', 'erc20', 'erc20n']
 
-      if (allParams.some(param => currentParams.includes(param) )) {
+      // Hide transfers if one of the appUrlPaths is included in the current url
+      if (appUrlPaths.some(param => currentParams.includes(param) )) {
         window.dom.hide("recent-transfers");
       } else {
         window.dom.show("recent-transfers");

--- a/src/html/transfers.html
+++ b/src/html/transfers.html
@@ -617,12 +617,13 @@
       if (!(window.ethInitialized && window.nearInitialized)) return;
 
       const transfers = await window.transfers.get();
-      const params = Object.keys(window.urlParams.get());
+      const currentParams = Object.keys(window.urlParams.get());
+      const allParams = ['new', 'erc20', 'erc20n']
 
-      if (transfers.length && !params.length) {
-        window.dom.show("recent-transfers");
-      } else {
+      if (allParams.some(param => currentParams.includes(param) )) {
         window.dom.hide("recent-transfers");
+      } else {
+        window.dom.show("recent-transfers");
       }
     }
 

--- a/src/html/transfers.html
+++ b/src/html/transfers.html
@@ -522,7 +522,8 @@
               `<button class="button--cta button-size--small" data-behavior="transferCallToAction">${transfer.callToAction}</button>`
           )}
           ${window.dom.toString(
-            (transfer.status === "completed" || !transfer.completedStep || // transfer completed or not yet approved
+            (transfer.status === "completed" || // transfer completed
+             (transfer.type === '@near-eth/nep141-erc20/natural-erc20/sendToNear' && !transfer.completedStep) || // transfer from Ethereum not yet approved
              (transfer.completedStep === 'approve-natural-erc20-to-nep141' && transfer.status === 'action-needed') || // approved but not transfered (not yet locked)
              (transfer.completedStep === 'approve-natural-erc20-to-nep141' && transfer.status === 'failed')) && // approved but not transfered (lock failed)
               `<button class="button--delete button-size--small" data-behavior="deleteTransfer"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/html/transfers.html
+++ b/src/html/transfers.html
@@ -274,7 +274,6 @@
 
     .transfer__footer {
       position: relative;
-      transition: height 0.2s;
       height: var(--input-height--small);
     }
 

--- a/src/html/transfers.html
+++ b/src/html/transfers.html
@@ -437,10 +437,6 @@
         window.urlParams.set({ new: "transfer" });
         window.render();
       });
-      window.dom.onClick("newRecovery", function startTransferRecovery() {
-        window.urlParams.set({ new: "restore" });
-        window.render();
-      });
       // transfers are rendered after page load, so we add one click handler to the
       // body tag to handle clicking each kind of button on a transfer
       document.querySelector("body").addEventListener("click", async (event) => {

--- a/src/html/transfers.html
+++ b/src/html/transfers.html
@@ -522,7 +522,9 @@
               `<button class="button--cta button-size--small" data-behavior="transferCallToAction">${transfer.callToAction}</button>`
           )}
           ${window.dom.toString(
-            transfer.status === "completed" &&
+            (transfer.status === "completed" || !transfer.completedStep || // completed on not yet approved
+             (transfer.completedStep === 'approve-natural-erc20-to-nep141' && transfer.status === 'action-needed') || // approved but not transfered (not yet locked)
+             (transfer.completedStep === 'approve-natural-erc20-to-nep141' && transfer.status === 'failed')) && // approved but not transfered (lock failed)
               `<button class="button--delete button-size--small" data-behavior="deleteTransfer"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M2 4H3.33333H14" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
                 <path d="M5.3335 4.00004V2.66671C5.3335 2.31309 5.47397 1.97395 5.72402 1.7239C5.97407 1.47385 6.31321 1.33337 6.66683 1.33337H9.3335C9.68712 1.33337 10.0263 1.47385 10.2763 1.7239C10.5264 1.97395 10.6668 2.31309 10.6668 2.66671V4.00004M12.6668 4.00004V13.3334C12.6668 13.687 12.5264 14.0261 12.2763 14.2762C12.0263 14.5262 11.6871 14.6667 11.3335 14.6667H4.66683C4.31321 14.6667 3.97407 14.5262 3.72402 14.2762C3.47397 14.0261 3.3335 13.687 3.3335 13.3334V4.00004H12.6668Z" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>

--- a/src/html/transfers.html
+++ b/src/html/transfers.html
@@ -522,7 +522,7 @@
               `<button class="button--cta button-size--small" data-behavior="transferCallToAction">${transfer.callToAction}</button>`
           )}
           ${window.dom.toString(
-            (transfer.status === "completed" || !transfer.completedStep || // completed on not yet approved
+            (transfer.status === "completed" || !transfer.completedStep || // transfer completed or not yet approved
              (transfer.completedStep === 'approve-natural-erc20-to-nep141' && transfer.status === 'action-needed') || // approved but not transfered (not yet locked)
              (transfer.completedStep === 'approve-natural-erc20-to-nep141' && transfer.status === 'failed')) && // approved but not transfered (lock failed)
               `<button class="button--delete button-size--small" data-behavior="deleteTransfer"><svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">

--- a/src/js/authEthereum.js
+++ b/src/js/authEthereum.js
@@ -8,7 +8,6 @@ import {
 import render from './render'
 import { onClick } from './domHelpers'
 import { chainIdToEthNetwork } from './utils'
-import * as urlParams from './urlParams'
 
 // SWAP IN YOUR OWN INFURA_ID FROM https://infura.io/dashboard/ethereum
 const INFURA_ID = '9c91979e95cb4ef8a61eb029b4217a1a'

--- a/src/js/domHelpers.js
+++ b/src/js/domHelpers.js
@@ -96,6 +96,12 @@ export function init () {
     setTimeout(() => window.location.reload())
   })
 
+  onClick('newRecovery', function startTransferRecovery () {
+    if (!(window.ethInitialized && window.nearInitialized)) return
+    window.urlParams.set({ new: 'restore' })
+    render()
+  })
+
   // avoid page refreshes when submitting "get" forms
   document.querySelectorAll('form[method="get"]').forEach(form => {
     form.onsubmit = e => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1272,28 +1272,29 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@near-eth/client@1.1.1", "@near-eth/client@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@near-eth/client/-/client-1.1.1.tgz#39e0611318091330ac10ad379f44f6085a686361"
-  integrity sha512-4mScA8DjGSrwPClsOfwGm3dnfaWLiTY+6HHogevIwhSOFp4ltJeQmMrO4dt2WusFMyQa0WuZl0Yzc+NhpYSGcA==
+"@near-eth/client@1.2.0", "@near-eth/client@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@near-eth/client/-/client-1.2.0.tgz#a618d16d8d4da89a40cbd0f3b6ce3f691c4f3e5d"
+  integrity sha512-6kkl4ngfMEimHjPpWiERauAMqHVx+O3T3f7LrzHmdg5u9RZLtBA9GO5LdRdmzTtALLHtxMgeT2RJit5snXo8fA==
   dependencies:
     bn.js "^5.1.3"
     decimal.js "^10.2.1"
     near-api-js "^0.39.0"
 
-"@near-eth/nep141-erc20@^1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@near-eth/nep141-erc20/-/nep141-erc20-1.2.4.tgz#c3f7a0235109922d468d4a136f674b8c1947d610"
-  integrity sha512-rbAGGvP7In4kqZrmmemZTZ2kpxt5UM2Rl6bxvqVDEsIwLNE20Aa/phqBomiajrTedfga6u3kgZKx4YGlFpY3PQ==
+"@near-eth/nep141-erc20@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@near-eth/nep141-erc20/-/nep141-erc20-1.3.1.tgz#8d3c3dba6daf5c0d5ee79bff574e5a754b63d884"
+  integrity sha512-VWm1+ULMOQ9hy2J+DOWZ0+qYhHup9DU+T83S6hAEnz95AKSBOmlO/O/6kTw2QiC5tZRXPg/Qi/GvPo7FKByh0g==
   dependencies:
-    "@near-eth/client" "1.1.1"
+    "@near-eth/client" "1.2.0"
     bn.js "^5.1.3"
     bs58 "^4.0.1"
     eth-object near/eth-object#54e03b8aac8208cf724e206d49ffb8bdd30451d7
     eth-revert-reason "^1.0.3"
-    eth-util-lite near/eth-util-lite#master
+    ethereumjs-util "^7.0.10"
     near-api-js "^0.39.0"
     promisfy "^1.2.0"
+    rlp "^2.2.6"
     web3 "^1.3.4"
     web3-utils "^1.3.4"
 
@@ -5322,6 +5323,18 @@ ethereumjs-util@^6.0.0, ethereumjs-util@^6.2.0:
     ethereum-cryptography "^0.1.3"
     ethjs-util "0.1.6"
     rlp "^2.2.3"
+
+ethereumjs-util@^7.0.10:
+  version "7.0.10"
+  resolved "https://registry.yarnpkg.com/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz#5fb7b69fa1fda0acc59634cf39d6b0291180fc1f"
+  integrity sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==
+  dependencies:
+    "@types/bn.js" "^5.1.0"
+    bn.js "^5.1.2"
+    create-hash "^1.1.2"
+    ethereum-cryptography "^0.1.3"
+    ethjs-util "0.1.6"
+    rlp "^2.2.4"
 
 ethereumjs-util@^7.0.3:
   version "7.0.8"
@@ -11400,7 +11413,7 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rlp@^2.0.0, rlp@^2.2.3, rlp@^2.2.4:
+rlp@^2.0.0, rlp@^2.2.3, rlp@^2.2.4, rlp@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/rlp/-/rlp-2.2.6.tgz#c80ba6266ac7a483ef1e69e8e2f056656de2fb2c"
   integrity sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==


### PR DESCRIPTION
- Allow the user to remove an Eth -> NEAR transfer before the lock tx is created.
There is no confusion because the transfer was never initiated on-chain so this is effectively deleting the transfer.
It is safer because the user may have another pending transaction with that token for example on uniswap, and if the allowance is consumed, the user will be stuck before the lock step with no way to recover. The allows the user to delete the transfer and start it again.
Note that the approve transaction is not lost as creating a new transfer will skip the approve step if allowance is enough

- Add restore functionality from landing page
![image](https://user-images.githubusercontent.com/29397451/113962696-297a5780-9863-11eb-937f-903bfc166794.png)
