### PR TITLE
fix: switch wallet from unsuported network

### DIFF
--- a/src/html/incorrect-network-modal.html
+++ b/src/html/incorrect-network-modal.html
@@ -10,6 +10,12 @@
     <h1 class="modal__heading">Incorrect Wallet Network</h1>
     <div data-behavior="modalMessage" class="modal__message"></div>
     <p class="modal__cta">Change your active wallet network to proceed.</p>
+    <button
+      class="button-variant--secondary button-size--small"
+      data-behavior="switchEthWallet"
+    >
+      Switch wallet
+    </button>
   </div>
 </div>
 
@@ -23,7 +29,8 @@
       // Disable scroll until correct eth network selected
       document.body.style.overflow = "hidden";
       window.dom.fill("modalMessage").with({
-        innerHTML: `The NEAR Testnet ↔︎ ${process.env.ethNetworkId} bridge requires an Ethereum wallet connected to ${process.env.ethNetworkId}.`,
+        innerHTML: `The ${window.bridgeName} bridge requires an Ethereum wallet connected to
+          ${process.env.ethNetworkId === 'main' ? 'mainnet' : process.env.ethNetworkId}.`,
       });
       window.dom.show("unsupportedNetworkModal");
     }

--- a/src/html/incorrect-network-modal.html
+++ b/src/html/incorrect-network-modal.html
@@ -3,7 +3,7 @@
   class="modal"
   style="display: none"
 >
-  <div class="modal__container">
+  <div class="modal__container" style="text-align: center;">
     <div class="modal-image__container">
       <!-- Modal Image Will Go Here -->
     </div>

--- a/src/js/authEthereum.js
+++ b/src/js/authEthereum.js
@@ -69,6 +69,13 @@ async function login () {
 }
 
 onClick('authEthereum', login)
+onClick('switchEthWallet', async () => {
+  window.ethInitialized = false
+  window.dom.hide('unsupportedNetworkModal')
+  await window.web3Modal.clearCachedProvider()
+  localStorage.removeItem('walletconnect')
+  login()
+})
 
 // on page load, check if user has already signed in via MetaMask
 if (window.web3Modal.cachedProvider) {

--- a/src/js/authEthereum.js
+++ b/src/js/authEthereum.js
@@ -8,6 +8,7 @@ import {
 import render from './render'
 import { onClick } from './domHelpers'
 import { chainIdToEthNetwork } from './utils'
+import * as urlParams from './urlParams'
 
 // SWAP IN YOUR OWN INFURA_ID FROM https://infura.io/dashboard/ethereum
 const INFURA_ID = '9c91979e95cb4ef8a61eb029b4217a1a'
@@ -71,10 +72,15 @@ async function login () {
 onClick('authEthereum', login)
 onClick('switchEthWallet', async () => {
   window.ethInitialized = false
-  window.dom.hide('unsupportedNetworkModal')
   await window.web3Modal.clearCachedProvider()
   localStorage.removeItem('walletconnect')
-  login()
+  window.dom.hide('unsupportedNetworkModal')
+  try {
+    await login()
+  } catch (error) {
+    // user closed modal without selecting wallet
+    window.location.reload()
+  }
 })
 
 // on page load, check if user has already signed in via MetaMask


### PR DESCRIPTION
Prevents the user from being stuck if the walletconnect connection
is lost and the network cannot be changed from mobile wallet, or if
mobile wallet doesn't support network change functionality.
![image](https://user-images.githubusercontent.com/29397451/114394338-0d194a80-9bd6-11eb-88ae-21e633ea8874.png)
